### PR TITLE
feat: dimension-specific leaderboards and radar chart profiles

### DIFF
--- a/INSIGHTS.md
+++ b/INSIGHTS.md
@@ -203,4 +203,42 @@ The current-era view reveals a more optimistic story. The industry *is* getting 
 
 ---
 
+---
+
+# What the Composite Score Hides: A Per-Dimension View
+
+*Composite scores generate interest, but per-dimension coverage is where the actionable insight lives. Different publishers have different priorities and contexts. The leaderboard now supports sorting by individual dimensions and a radar chart profile for each publisher.*
+
+## The Same Score, Completely Different Profiles
+
+Two publishers can score a 50 and look nothing alike:
+
+| Dimension | Publisher A (Access-strong) | Publisher B (People-strong) |
+|-----------|---------------------------|----------------------------|
+| Provenance | 30% | 60% |
+| People | 20% | 90% |
+| Organizations | 10% | 5% |
+| Funding | 15% | 10% |
+| Access | 90% | 40% |
+| **Composite** | **~50** | **~50** |
+
+The composite score treats these as equivalent. They're not. Publisher A has prioritized open access metadata (licenses, abstracts, full-text links). Publisher B has invested in author identification (ORCIDs). Both have legitimate strategies — the radar chart makes this visible.
+
+## Dimension Leaders Don't Always Lead Overall
+
+When you sort the leaderboard by individual dimensions, the top 10 changes dramatically:
+
+- **Sort by People (ORCID)**: Publishers like PLoS (94% current), APS (98%), and ASM (99%) rise — they've invested heavily in author identification even if their overall scores are mid-range.
+- **Sort by Funding**: Almost everyone drops. The median is 0%. The few publishers with meaningful funder metadata stand out starkly.
+- **Sort by Organizations (ROR)**: Life Science Alliance (86%) is essentially alone at the top. Even MDPI — a B-grade publisher overall — has 0% ROR coverage.
+- **Sort by Access**: Many publishers score well here (licenses + abstracts), which inflates their composite but masks gaps elsewhere.
+
+## The Practical Takeaway
+
+A publisher scoring an F overall but 90%+ on a single dimension isn't failing — they've made a strategic investment that the composite score doesn't reward. Per-dimension sorting lets the community recognize these efforts and helps publishers decide where to invest next based on what matters most to their stakeholders.
+
+This is why the leaderboard now lets you click any dimension column to re-rank, and click any publisher to see their full radar profile.
+
+---
+
 *Generated from [Nexus Score](https://nexus-score.vercel.app) leaderboard data. Last updated: March 2026.*

--- a/apps/web/src/app/member/[id]/page.tsx
+++ b/apps/web/src/app/member/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
 } from '@nexus-score/core';
 import { ScoreCard } from '@/components/score-card';
 import { DimensionChart } from '@/components/dimension-chart';
+import { DimensionRadar } from '@/components/dimension-radar';
 import { MetricsTable } from '@/components/metrics-table';
 import { RecommendationsList } from '@/components/recommendations-list';
 import { MemberSearch } from '@/components/member-search';
@@ -628,7 +629,16 @@ export default async function MemberPage({ params }: PageProps) {
               )}
             </div>
 
-            <DimensionChart dimensions={score.dimensions} />
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+              <DimensionChart dimensions={score.dimensions} />
+              <DimensionRadar dimensions={{
+                provenance: score.dimensions.provenance.percentage,
+                people: score.dimensions.people.percentage,
+                organizations: score.dimensions.organizations.percentage,
+                funding: score.dimensions.funding.percentage,
+                access: score.dimensions.access.percentage,
+              }} />
+            </div>
 
             {/* Content Type Breakdown */}
             {contentTypeScores && contentTypeScores.length > 0 && (

--- a/apps/web/src/components/current-leaderboard-table.tsx
+++ b/apps/web/src/components/current-leaderboard-table.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
+import { PublisherRadar } from './publisher-radar';
 
 type Grade = 'A' | 'B' | 'C' | 'D' | 'F';
 
@@ -51,7 +52,8 @@ const gradeColors: Record<Grade, string> = {
   F: 'bg-red-100 text-red-800',
 };
 
-type SortField = 'default' | 'score' | 'works' | 'improvement' | 'overall';
+type DimensionKey = 'provenance' | 'people' | 'organizations' | 'funding' | 'access';
+type SortField = 'default' | 'score' | 'works' | 'improvement' | 'overall' | DimensionKey;
 type SortDirection = 'desc' | 'asc';
 
 export function CurrentLeaderboardTable({ leaderboard, totalActive, availableContentTypes }: Props) {
@@ -61,6 +63,7 @@ export function CurrentLeaderboardTable({ leaderboard, totalActive, availableCon
   const [sortField, setSortField] = useState<SortField>('default');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [contentTypeFilter, setContentTypeFilter] = useState<string>('all');
+  const [radarEntry, setRadarEntry] = useState<CurrentLeaderboardEntry | null>(null);
 
   const getCtScore = (entry: CurrentLeaderboardEntry): number | null => {
     if (contentTypeFilter === 'all') return null;
@@ -134,6 +137,13 @@ export function CurrentLeaderboardTable({ leaderboard, totalActive, availableCon
     } else if (sortField === 'overall') {
       filtered = [...filtered].sort((a, b) =>
         sortDirection === 'desc' ? b.overallScore - a.overallScore : a.overallScore - b.overallScore
+      );
+    } else if (['provenance', 'people', 'organizations', 'funding', 'access'].includes(sortField)) {
+      const dim = sortField as DimensionKey;
+      filtered = [...filtered].sort((a, b) =>
+        sortDirection === 'desc'
+          ? b.dimensions[dim] - a.dimensions[dim]
+          : a.dimensions[dim] - b.dimensions[dim]
       );
     }
 
@@ -305,7 +315,7 @@ export function CurrentLeaderboardTable({ leaderboard, totalActive, availableCon
         </span>
         {sortField !== 'default' && (
           <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700">
-            Sorted by {sortField} {sortDirection === 'desc' ? '(high to low)' : '(low to high)'}
+            Sorted by {sortField === 'organizations' ? 'orgs' : sortField} {sortDirection === 'desc' ? '(high to low)' : '(low to high)'}
             <button
               onClick={() => {
                 setSortField('default');
@@ -368,19 +378,29 @@ export function CurrentLeaderboardTable({ leaderboard, totalActive, availableCon
               </th>
               )}
               <th className="hidden px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500 lg:table-cell">
-                Prov.
+                <button onClick={() => handleSortToggle('provenance')} className="inline-flex items-center gap-1 hover:text-gray-700">
+                  Prov.{getSortIcon('provenance')}
+                </button>
               </th>
               <th className="hidden px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500 lg:table-cell">
-                People
+                <button onClick={() => handleSortToggle('people')} className="inline-flex items-center gap-1 hover:text-gray-700">
+                  People{getSortIcon('people')}
+                </button>
               </th>
               <th className="hidden px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500 xl:table-cell">
-                Orgs
+                <button onClick={() => handleSortToggle('organizations')} className="inline-flex items-center gap-1 hover:text-gray-700">
+                  Orgs{getSortIcon('organizations')}
+                </button>
               </th>
               <th className="hidden px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500 xl:table-cell">
-                Funding
+                <button onClick={() => handleSortToggle('funding')} className="inline-flex items-center gap-1 hover:text-gray-700">
+                  Funding{getSortIcon('funding')}
+                </button>
               </th>
               <th className="hidden px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500 xl:table-cell">
-                Access
+                <button onClick={() => handleSortToggle('access')} className="inline-flex items-center gap-1 hover:text-gray-700">
+                  Access{getSortIcon('access')}
+                </button>
               </th>
               <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
                 <button
@@ -409,7 +429,7 @@ export function CurrentLeaderboardTable({ leaderboard, totalActive, availableCon
                 const gradeDowngrade = gradeOrder[displayGrade] < gradeOrder[entry.overallGrade];
 
                 return (
-                  <tr key={entry.id} className="hover:bg-gray-50">
+                  <tr key={entry.id} className="hover:bg-gray-50 cursor-pointer" onClick={() => setRadarEntry(entry)}>
                     <td className="whitespace-nowrap px-4 py-4">
                       <span className="text-lg font-bold text-gray-400">
                         {useOriginalRank && displayRank <= 3 ? (
@@ -427,6 +447,7 @@ export function CurrentLeaderboardTable({ leaderboard, totalActive, availableCon
                       <Link
                         href={`/member/${entry.id}`}
                         className="font-medium text-gray-900 hover:text-emerald-600"
+                        onClick={(e) => e.stopPropagation()}
                       >
                         {entry.name}
                       </Link>
@@ -592,6 +613,20 @@ export function CurrentLeaderboardTable({ leaderboard, totalActive, availableCon
             </button>
           </div>
         </div>
+      )}
+      {radarEntry && (
+        <>
+          <div className="fixed inset-0 z-40 bg-black/20" onClick={() => setRadarEntry(null)} />
+          <PublisherRadar
+            id={radarEntry.id}
+            name={radarEntry.name}
+            score={getCtScore(radarEntry) ?? radarEntry.score}
+            grade={(getCtGrade(radarEntry) ?? radarEntry.grade)}
+            dimensions={radarEntry.dimensions}
+            contentTypeFilter={contentTypeFilter}
+            onClose={() => setRadarEntry(null)}
+          />
+        </>
       )}
     </div>
   );

--- a/apps/web/src/components/dimension-radar.tsx
+++ b/apps/web/src/components/dimension-radar.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { Radar, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, ResponsiveContainer } from 'recharts';
+
+interface DimensionRadarProps {
+  dimensions: {
+    provenance: number;
+    people: number;
+    organizations: number;
+    funding: number;
+    access: number;
+  };
+}
+
+export function DimensionRadar({ dimensions }: DimensionRadarProps) {
+  const data = [
+    { dimension: 'Provenance', value: dimensions.provenance },
+    { dimension: 'People', value: dimensions.people },
+    { dimension: 'Organizations', value: dimensions.organizations },
+    { dimension: 'Funding', value: dimensions.funding },
+    { dimension: 'Access', value: dimensions.access },
+  ];
+
+  return (
+    <div className="rounded-xl border bg-white p-4 sm:p-6 shadow-sm">
+      <h3 className="text-lg font-semibold text-gray-900">Dimension Profile</h3>
+      <p className="mt-1 text-sm text-gray-500">Visual overview of metadata coverage across all five dimensions.</p>
+      <div className="h-64 mt-4">
+        <ResponsiveContainer width="100%" height="100%">
+          <RadarChart data={data} cx="50%" cy="50%" outerRadius="75%">
+            <PolarGrid stroke="#e5e7eb" />
+            <PolarAngleAxis dataKey="dimension" tick={{ fontSize: 12, fill: '#6b7280' }} />
+            <PolarRadiusAxis angle={90} domain={[0, 100]} tick={{ fontSize: 9, fill: '#9ca3af' }} tickCount={5} />
+            <Radar
+              dataKey="value"
+              stroke="#3b82f6"
+              fill="#3b82f6"
+              fillOpacity={0.15}
+              strokeWidth={2}
+            />
+          </RadarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/leaderboard-table.tsx
+++ b/apps/web/src/components/leaderboard-table.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
+import { PublisherRadar } from './publisher-radar';
 
 type Grade = 'A' | 'B' | 'C' | 'D' | 'F';
 
@@ -56,7 +57,8 @@ const rankStyles: Record<number, string> = {
   3: 'text-amber-600',
 };
 
-type SortField = 'default' | 'score' | 'works' | 'improvement';
+type DimensionKey = 'provenance' | 'people' | 'organizations' | 'funding' | 'access';
+type SortField = 'default' | 'score' | 'works' | 'improvement' | DimensionKey;
 type SortDirection = 'desc' | 'asc';
 type ViewMode = 'overall' | 'progress';
 
@@ -68,6 +70,7 @@ export function LeaderboardTable({ leaderboard, totalWithWorks, availableContent
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [viewMode, setViewMode] = useState<ViewMode>('overall');
   const [contentTypeFilter, setContentTypeFilter] = useState<string>('all');
+  const [radarEntry, setRadarEntry] = useState<LeaderboardEntry | null>(null);
 
   // Check if improvement data is available (non-null values with meaningful backfile scores)
   const hasImprovementData = leaderboard.some(e =>
@@ -161,6 +164,13 @@ export function LeaderboardTable({ leaderboard, totalWithWorks, availableContent
           ? (b.improvement ?? 0) - (a.improvement ?? 0)
           : (a.improvement ?? 0) - (b.improvement ?? 0)
       );
+    } else if (['provenance', 'people', 'organizations', 'funding', 'access'].includes(sortField)) {
+      const dim = sortField as DimensionKey;
+      filtered = [...filtered].sort((a, b) =>
+        sortDirection === 'desc'
+          ? b.dimensions[dim] - a.dimensions[dim]
+          : a.dimensions[dim] - b.dimensions[dim]
+      );
     }
 
     // In progress view, default sort by improvement
@@ -201,7 +211,7 @@ export function LeaderboardTable({ leaderboard, totalWithWorks, availableContent
     }
   };
 
-  const handleSortToggle = (field: 'score' | 'works' | 'improvement') => {
+  const handleSortToggle = (field: 'score' | 'works' | 'improvement' | DimensionKey) => {
     if (sortField === field) {
       // Toggle direction or reset to default
       if (sortDirection === 'desc') {
@@ -225,7 +235,7 @@ export function LeaderboardTable({ leaderboard, totalWithWorks, availableContent
     setCurrentPage(1);
   };
 
-  const getSortIcon = (field: 'score' | 'works' | 'improvement') => {
+  const getSortIcon = (field: SortField) => {
     if (sortField !== field) {
       return (
         <svg className="h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -412,7 +422,7 @@ export function LeaderboardTable({ leaderboard, totalWithWorks, availableContent
         </span>
         {sortField !== 'default' && (
           <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
-            Sorted by {sortField} {sortDirection === 'desc' ? '(high to low)' : '(low to high)'}
+            Sorted by {sortField === 'organizations' ? 'orgs' : sortField} {sortDirection === 'desc' ? '(high to low)' : '(low to high)'}
             <button
               onClick={() => {
                 setSortField('default');
@@ -473,19 +483,29 @@ export function LeaderboardTable({ leaderboard, totalWithWorks, availableContent
                     Grade
                   </th>
                   <th className="hidden px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500 md:table-cell">
-                    Provenance
+                    <button onClick={() => handleSortToggle('provenance')} className="inline-flex items-center gap-1 hover:text-gray-700">
+                      Provenance{getSortIcon('provenance')}
+                    </button>
                   </th>
                   <th className="hidden px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500 md:table-cell">
-                    People
+                    <button onClick={() => handleSortToggle('people')} className="inline-flex items-center gap-1 hover:text-gray-700">
+                      People{getSortIcon('people')}
+                    </button>
                   </th>
                   <th className="hidden px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500 lg:table-cell">
-                    Orgs
+                    <button onClick={() => handleSortToggle('organizations')} className="inline-flex items-center gap-1 hover:text-gray-700">
+                      Orgs{getSortIcon('organizations')}
+                    </button>
                   </th>
                   <th className="hidden px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500 lg:table-cell">
-                    Funding
+                    <button onClick={() => handleSortToggle('funding')} className="inline-flex items-center gap-1 hover:text-gray-700">
+                      Funding{getSortIcon('funding')}
+                    </button>
                   </th>
                   <th className="hidden px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500 lg:table-cell">
-                    Access
+                    <button onClick={() => handleSortToggle('access')} className="inline-flex items-center gap-1 hover:text-gray-700">
+                      Access{getSortIcon('access')}
+                    </button>
                   </th>
                 </>
               )}
@@ -512,7 +532,7 @@ export function LeaderboardTable({ leaderboard, totalWithWorks, availableContent
                 const useOriginalRank = contentTypeFilter === 'all' && sortField === 'default' && !searchQuery && gradeFilter === 'all';
                 const displayRank = useOriginalRank ? entry.rank : startIndex + index + 1;
                 return (
-                <tr key={entry.id} className="hover:bg-gray-50">
+                <tr key={entry.id} className="hover:bg-gray-50 cursor-pointer" onClick={() => setRadarEntry(entry)}>
                   <td className="whitespace-nowrap px-4 py-4">
                     {viewMode === 'progress' ? (
                       <span className="text-lg font-bold text-gray-400">
@@ -541,6 +561,7 @@ export function LeaderboardTable({ leaderboard, totalWithWorks, availableContent
                     <Link
                       href={`/member/${entry.id}`}
                       className="font-medium text-gray-900 hover:text-blue-600"
+                      onClick={(e) => e.stopPropagation()}
                     >
                       {entry.name}
                     </Link>
@@ -694,6 +715,20 @@ export function LeaderboardTable({ leaderboard, totalWithWorks, availableContent
             </button>
           </div>
         </div>
+      )}
+      {radarEntry && (
+        <>
+          <div className="fixed inset-0 z-40 bg-black/20" onClick={() => setRadarEntry(null)} />
+          <PublisherRadar
+            id={radarEntry.id}
+            name={radarEntry.name}
+            score={getCtScore(radarEntry) ?? radarEntry.score}
+            grade={(getCtGrade(radarEntry) ?? radarEntry.grade)}
+            dimensions={radarEntry.dimensions}
+            contentTypeFilter={contentTypeFilter}
+            onClose={() => setRadarEntry(null)}
+          />
+        </>
       )}
     </div>
   );

--- a/apps/web/src/components/publisher-radar.tsx
+++ b/apps/web/src/components/publisher-radar.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import Link from 'next/link';
+import { Radar, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, ResponsiveContainer } from 'recharts';
+import { X, ExternalLink } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type Grade = 'A' | 'B' | 'C' | 'D' | 'F';
+
+const gradeColors: Record<Grade, string> = {
+  A: 'bg-green-100 text-green-800',
+  B: 'bg-blue-100 text-blue-800',
+  C: 'bg-yellow-100 text-yellow-800',
+  D: 'bg-orange-100 text-orange-800',
+  F: 'bg-red-100 text-red-800',
+};
+
+interface PublisherRadarProps {
+  id: number;
+  name: string;
+  score: number;
+  grade: string;
+  dimensions: {
+    provenance: number;
+    people: number;
+    organizations: number;
+    funding: number;
+    access: number;
+  };
+  contentTypeFilter?: string;
+  onClose: () => void;
+}
+
+const DIMENSION_LABELS: Record<string, { label: string; description: string }> = {
+  provenance: { label: 'Provenance', description: 'References, update policies, similarity check' },
+  people: { label: 'People', description: 'ORCID coverage' },
+  organizations: { label: 'Organizations', description: 'Affiliations and ROR IDs' },
+  funding: { label: 'Funding', description: 'Funder registry and award numbers' },
+  access: { label: 'Access', description: 'Licenses, full-text links, abstracts' },
+};
+
+export function PublisherRadar({ id, name, score, grade, dimensions, contentTypeFilter, onClose }: PublisherRadarProps) {
+  const data = Object.entries(dimensions).map(([key, value]) => ({
+    dimension: DIMENSION_LABELS[key]?.label || key,
+    value,
+    fullMark: 100,
+  }));
+
+  const strongest = Object.entries(dimensions).sort((a, b) => b[1] - a[1])[0];
+  const weakest = Object.entries(dimensions).sort((a, b) => a[1] - b[1])[0];
+
+  return (
+    <div className="fixed inset-y-0 right-0 z-50 w-full max-w-md bg-white shadow-2xl border-l border-gray-200 overflow-y-auto">
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-gray-100 bg-white px-6 py-4">
+        <div>
+          <h2 className="text-sm font-semibold text-gray-900 truncate max-w-[280px]">{name}</h2>
+          <div className="flex items-center gap-2 mt-1">
+            <span className="text-2xl font-bold text-gray-900">{score}</span>
+            <span className="text-sm text-gray-400">/100</span>
+            <span className={cn('inline-flex rounded-full px-2 py-0.5 text-xs font-bold', gradeColors[grade as Grade] || 'bg-gray-100 text-gray-800')}>
+              {grade}
+            </span>
+          </div>
+          <Link href={`/member/${id}`} className="inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-800 mt-1">
+            View full profile <ExternalLink className="h-3 w-3" />
+          </Link>
+        </div>
+        <button onClick={onClose} className="rounded-lg p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-700 transition-colors">
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      <div className="px-6 py-6">
+        <h3 className="text-xs font-medium uppercase tracking-wider text-gray-500 mb-2">Dimension Profile</h3>
+        {contentTypeFilter && contentTypeFilter !== 'all' && (
+          <p className="text-[10px] text-amber-600 bg-amber-50 rounded px-2 py-1 mb-2">Dimensions reflect overall coverage — per-content-type breakdown is not available from Crossref.</p>
+        )}
+        <div className="h-72">
+          <ResponsiveContainer width="100%" height="100%">
+            <RadarChart data={data} cx="50%" cy="50%" outerRadius="75%">
+              <PolarGrid stroke="#e5e7eb" />
+              <PolarAngleAxis dataKey="dimension" tick={{ fontSize: 11, fill: '#6b7280' }} />
+              <PolarRadiusAxis angle={90} domain={[0, 100]} tick={{ fontSize: 9, fill: '#9ca3af' }} tickCount={5} />
+              <Radar
+                name={name}
+                dataKey="value"
+                stroke="#3b82f6"
+                fill="#3b82f6"
+                fillOpacity={0.15}
+                strokeWidth={2}
+              />
+            </RadarChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div className="mt-6 space-y-3">
+          {Object.entries(dimensions).map(([key, value]) => {
+            const info = DIMENSION_LABELS[key];
+            return (
+              <div key={key}>
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-sm font-medium text-gray-700">{info?.label || key}</span>
+                  <span className="text-sm font-mono text-gray-500">{value}%</span>
+                </div>
+                <div className="h-2 rounded-full bg-gray-100">
+                  <div
+                    className={cn(
+                      'h-2 rounded-full transition-all',
+                      value >= 80 ? 'bg-green-500' : value >= 50 ? 'bg-yellow-500' : value >= 20 ? 'bg-orange-500' : 'bg-red-500'
+                    )}
+                    style={{ width: `${value}%` }}
+                  />
+                </div>
+                <p className="text-[10px] text-gray-400 mt-0.5">{info?.description}</p>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-6 rounded-lg bg-gray-50 p-4 space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-gray-500">Strongest</span>
+            <span className="font-medium text-green-700">
+              {DIMENSION_LABELS[strongest[0]]?.label} ({strongest[1]}%)
+            </span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-gray-500">Weakest</span>
+            <span className="font-medium text-red-700">
+              {DIMENSION_LABELS[weakest[0]]?.label} ({weakest[1]}%)
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Sortable dimension columns on both overall and current-era leaderboards — click any dimension header (Provenance, People, Orgs, Funding, Access) to re-rank
- Radar chart side overlay — click any publisher row to see their five-dimension profile
- Radar chart on individual publisher pages alongside existing dimension bars
- New "What the Composite Score Hides" section in INSIGHTS.md

## Why

This was inspired by [feedback from Bianca Kramer](https://www.linkedin.com/feed/update/urn:li:activity:7441740521741463552?commentUrn=urn%3Ali%3Acomment%3A%28activity%3A7441740521741463552%2C7441854880903774209%29&dashCommentUrn=urn%3Ali%3Afsd_comment%3A%287441854880903774209%2Curn%3Ali%3Aactivity%3A7441740521741463552%29) on the original LinkedIn thread:

> *"The weighted scoring introduces a subjective element... the subsequent ranking further masks contextual differences and priorities that are relevant from both providers' and users' perspective. It's also important to look at the coverage of metadata types separately."*

She's right. Two publishers can score a 50 and look nothing alike — one strong on access, the other on people. The composite score treats them as equivalent. Per-dimension sorting and radar charts make those differences visible, recognizing publishers who lead in specific areas even if their composite is mid-range.

## Test plan

- [x] Click dimension column headers on `/leaderboard` — verify sorting works both directions
- [x] Click dimension column headers on `/leaderboard/current` — same
- [x] Click any publisher row — radar overlay opens with correct dimensions
- [x] Click "View full profile" link in overlay — navigates to `/member/[id]`
- [x] Visit any `/member/[id]` page — radar chart appears next to dimension bars
- [x] Apply content-type filter, click a row — amber note shows about overall dimensions