### PR TITLE
feat: institutional research visibility analysis (v0.2.0)

### DIFF
--- a/apps/gap-fixer/package.json
+++ b/apps/gap-fixer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-score/gap-fixer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 3001",

--- a/apps/gap-fixer/package.json
+++ b/apps/gap-fixer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-score/gap-fixer",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 3001",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-score/web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@nexus-score/web",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "generate-leaderboard": "tsx scripts/generate-leaderboard.ts"
+    "generate-leaderboard": "tsx scripts/generate-leaderboard.ts",
+    "analyze:institution": "tsx scripts/analyze-institution.ts"
   },
   "dependencies": {
     "@nexus-score/core": "workspace:*",

--- a/apps/web/scripts/analyze-institution.ts
+++ b/apps/web/scripts/analyze-institution.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env npx tsx
+/**
+ * Institutional Research Visibility Report (CLI)
+ *
+ * Usage:
+ *   pnpm --filter web analyze:institution -- --ror 052gg0110
+ *   pnpm --filter web analyze:institution -- --search "University of Oxford"
+ *   pnpm --filter web analyze:institution -- --ror 052gg0110 --days 90
+ */
+
+import { analyzeInstitution, searchInstitutions } from '../src/lib/analyze-institution.js';
+import type { InstitutionReport } from '../src/lib/publisher-map.js';
+
+function parseArgs(): { ror?: string; search?: string; days: number } {
+  const args = process.argv.slice(2);
+  let ror: string | undefined;
+  let search: string | undefined;
+  let days = 90;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--ror' && args[i + 1]) { ror = args[++i]; }
+    else if (args[i] === '--search' && args[i + 1]) { search = args[++i]; }
+    else if (args[i] === '--days' && args[i + 1]) { days = parseInt(args[++i], 10); }
+  }
+  return { ror, search, days };
+}
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s.slice(0, n) : s + ' '.repeat(n - s.length);
+}
+function padNum(s: string, n: number): string {
+  return s.length >= n ? s : ' '.repeat(n - s.length) + s;
+}
+
+function formatReport(report: InstitutionReport): string {
+  const lines: string[] = [];
+  const w = 88;
+  const sep = '='.repeat(w);
+  const thin = '-'.repeat(w);
+
+  lines.push('');
+  lines.push(sep);
+  lines.push(`  ${report.institution.name} (${report.institution.country}) — Research Visibility`);
+  lines.push(`  ${report.dateRange}`);
+  lines.push(
+    `  ${report.totalArticles.toLocaleString()} articles total | ${report.trackedArticles.toLocaleString()} tracked | ${report.measuredArticles.toLocaleString()} measured`
+  );
+  lines.push(sep);
+  lines.push('');
+
+  lines.push('  WHAT PUBLISHERS DEPOSIT TO CROSSREF (observed from work records)');
+  lines.push(thin);
+  lines.push(
+    `  ${pad('Publisher', 26)} ${padNum('Articles', 8)} ${padNum('Affil', 7)} ${padNum('AnyROR', 8)} ${padNum('OxROR', 8)} ${padNum('Funder', 7)} ${padNum('Abstr', 7)} ${padNum('ORCID', 7)}`
+  );
+  lines.push(thin);
+
+  for (const p of report.publishers) {
+    if (!p.measured) {
+      lines.push(
+        `  ${pad(p.name, 26)} ${padNum(p.articles.toLocaleString(), 8)}    sample < ${report.notes.minSampleSize}, not measured`
+      );
+      continue;
+    }
+    const instRorPct = (p.institutionalRor / p.articles) * 100;
+    lines.push(
+      `  ${pad(p.name, 26)} ${padNum(p.articles.toLocaleString(), 8)} ${padNum(p.coverage.affiliations.toFixed(0) + '%', 7)} ${padNum(p.coverage.rorIds.toFixed(0) + '%', 8)} ${padNum(instRorPct.toFixed(0) + '%', 8)} ${padNum(p.coverage.funders.toFixed(0) + '%', 7)} ${padNum(p.coverage.abstracts.toFixed(0) + '%', 7)} ${padNum(p.coverage.orcids.toFixed(0) + '%', 7)}`
+    );
+  }
+
+  lines.push(thin);
+  lines.push(
+    `  ${pad('TOTAL (measured)', 26)} ${padNum(report.measuredArticles.toLocaleString(), 8)} ${padNum(report.totals.affiliationPercent.toFixed(0) + '%', 7)} ${padNum(report.totals.rorPercent.toFixed(0) + '%', 8)} ${padNum(report.totals.institutionalRorPercent.toFixed(0) + '%', 8)} ${padNum(report.totals.funderPercent.toFixed(0) + '%', 7)} ${padNum(report.totals.abstractPercent.toFixed(0) + '%', 7)}`
+  );
+  lines.push(sep);
+
+  if (report.unmappedPublishers.length > 0) {
+    lines.push('');
+    lines.push('  NOT ANALYZED (publishers not in our Crossref member mapping)');
+    lines.push(thin);
+    const totalUnmapped = report.unmappedPublishers.reduce((s, u) => s + u.articles, 0);
+    for (const u of report.unmappedPublishers.slice(0, 15)) {
+      lines.push(`  ${pad(u.name, 60)} ${padNum(u.articles.toLocaleString(), 8)}`);
+    }
+    if (report.unmappedPublishers.length > 15) {
+      lines.push(`  ... and ${report.unmappedPublishers.length - 15} more`);
+    }
+    lines.push(thin);
+    lines.push(`  ${pad('UNMAPPED TOTAL', 60)} ${padNum(totalUnmapped.toLocaleString(), 8)}`);
+    lines.push(sep);
+  }
+
+  lines.push('');
+  lines.push(`  ${report.notes.source}`);
+  lines.push(`  ${report.notes.contentType}. Sample threshold: ${report.notes.minSampleSize} articles.`);
+  lines.push('');
+  lines.push('  OxROR = this institution\'s ROR present on any author affiliation.');
+  lines.push('  AnyROR = any ROR ID present in author affiliations.');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+async function main() {
+  const { ror, search, days } = parseArgs();
+
+  if (!ror && !search) {
+    console.error('Usage:');
+    console.error('  --ror <ror_id>       Analyze by ROR ID (e.g., 052gg0110)');
+    console.error('  --search "<name>"    Search for an institution');
+    console.error('  --days <n>           Window size in days (default: 90)');
+    process.exit(1);
+  }
+
+  let targetRor = ror;
+
+  if (search && !ror) {
+    console.log(`\nSearching for "${search}"...\n`);
+    const results = await searchInstitutions(search);
+    if (results.length === 0) { console.error('No institutions found.'); process.exit(1); }
+    console.log('Results:');
+    results.forEach((r, i) => console.log(`  ${i + 1}. ${r.name} (${r.country}) - ROR: ${r.ror}`));
+    console.log(`\nUsing first result: ${results[0].name}\n`);
+    targetRor = results[0].ror;
+  }
+
+  if (!targetRor) { console.error('No ROR ID resolved.'); process.exit(1); }
+
+  console.log(`Analyzing institution (ROR: ${targetRor}, window: ${days} days)...`);
+  console.log('  1. Fetching DOIs from OpenAlex (cursor pagination)...');
+  console.log('  2. Fetching Crossref work records in batches and inspecting each...');
+
+  const report = await analyzeInstitution(targetRor, days);
+  console.log(formatReport(report));
+}
+
+main().catch((err) => { console.error('Error:', err.message); process.exit(1); });

--- a/apps/web/src/app/analysis/institution/page.tsx
+++ b/apps/web/src/app/analysis/institution/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Suspense, useEffect, useRef, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
 import type { InstitutionReport } from '../../../lib/publisher-map';
 import { PublisherGapTable, GapSummaryTable } from '../../../components/publisher-gap-table';
 import { StakeholderImpact } from '../../../components/stakeholder-impact';
@@ -13,11 +12,7 @@ interface SearchResult {
   country: string;
 }
 
-function InstitutionAnalysisPageInner() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const urlRor = searchParams.get('ror');
-
+export default function InstitutionAnalysisPage() {
   const [query, setQuery] = useState('');
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [report, setReport] = useState<InstitutionReport | null>(null);
@@ -26,30 +21,37 @@ function InstitutionAnalysisPageInner() {
   const [error, setError] = useState('');
   const analyzedRorRef = useRef<string | null>(null);
 
-  // Run analysis when ?ror=... is in the URL. This gives each analyzed
-  // institution a unique, shareable URL and makes pageviews show up
-  // per-institution in Vercel Analytics.
+  // On mount + whenever the browser URL changes, if ?ror=... is present
+  // kick off the analysis. Uses native browser APIs (no Next router hooks)
+  // so we don't need a Suspense boundary. Vercel Analytics picks up
+  // history.pushState events for per-institution pageview tracking.
   useEffect(() => {
-    if (!urlRor || urlRor === analyzedRorRef.current) return;
-    analyzedRorRef.current = urlRor;
-    (async () => {
-      setLoading(true);
-      setError('');
-      setSearchResults([]);
-      try {
-        const res = await fetch(`/api/analyze-institution?ror=${urlRor}`);
-        if (!res.ok) {
-          const data = await res.json().catch(() => ({}));
-          throw new Error(data.error || `Analysis failed (HTTP ${res.status})`);
+    function runFromUrl() {
+      const urlRor = new URLSearchParams(window.location.search).get('ror');
+      if (!urlRor || urlRor === analyzedRorRef.current) return;
+      analyzedRorRef.current = urlRor;
+      void (async () => {
+        setLoading(true);
+        setError('');
+        setSearchResults([]);
+        try {
+          const res = await fetch(`/api/analyze-institution?ror=${urlRor}`);
+          if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            throw new Error(data.error || `Analysis failed (HTTP ${res.status})`);
+          }
+          const data: InstitutionReport = await res.json();
+          setReport(data);
+        } catch (err) {
+          setError(err instanceof Error ? err.message : 'Analysis failed.');
         }
-        const data: InstitutionReport = await res.json();
-        setReport(data);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Analysis failed.');
-      }
-      setLoading(false);
-    })();
-  }, [urlRor]);
+        setLoading(false);
+      })();
+    }
+    runFromUrl();
+    window.addEventListener('popstate', runFromUrl);
+    return () => window.removeEventListener('popstate', runFromUrl);
+  }, []);
 
   async function handleSearch() {
     if (!query.trim()) return;
@@ -68,10 +70,31 @@ function InstitutionAnalysisPageInner() {
   }
 
   function handleAnalyze(ror: string) {
-    // Push to URL — the useEffect above will kick off the analysis. This
-    // makes each institution a distinct page view and supports sharing.
-    const params = new URLSearchParams({ ror });
-    router.push(`/analysis/institution?${params.toString()}`, { scroll: false });
+    // Push URL so each analyzed institution is a distinct Vercel Analytics
+    // pageview (their script patches history.pushState) and the link is
+    // shareable. Then trigger the analysis directly.
+    const newUrl = `/analysis/institution?ror=${encodeURIComponent(ror)}`;
+    if (window.location.pathname + window.location.search !== newUrl) {
+      window.history.pushState(null, '', newUrl);
+    }
+    analyzedRorRef.current = ror;
+    void (async () => {
+      setLoading(true);
+      setError('');
+      setSearchResults([]);
+      try {
+        const res = await fetch(`/api/analyze-institution?ror=${ror}`);
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.error || `Analysis failed (HTTP ${res.status})`);
+        }
+        const data: InstitutionReport = await res.json();
+        setReport(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Analysis failed.');
+      }
+      setLoading(false);
+    })();
   }
 
   return (
@@ -428,11 +451,3 @@ function StatCard({
   );
 }
 
-// useSearchParams needs a Suspense boundary in Next.js App Router.
-export default function InstitutionAnalysisPage() {
-  return (
-    <Suspense fallback={<div className="min-h-screen" />}>
-      <InstitutionAnalysisPageInner />
-    </Suspense>
-  );
-}

--- a/apps/web/src/app/analysis/institution/page.tsx
+++ b/apps/web/src/app/analysis/institution/page.tsx
@@ -1,0 +1,409 @@
+'use client';
+
+import { useState } from 'react';
+import type { InstitutionReport } from '../../../lib/publisher-map';
+import { PublisherGapTable, GapSummaryTable } from '../../../components/publisher-gap-table';
+import { StakeholderImpact } from '../../../components/stakeholder-impact';
+import { InstitutionalBlindSpots } from '../../../components/institutional-blind-spots';
+
+interface SearchResult {
+  name: string;
+  ror: string;
+  country: string;
+}
+
+export default function InstitutionAnalysisPage() {
+  const [query, setQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [report, setReport] = useState<InstitutionReport | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [searching, setSearching] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleSearch() {
+    if (!query.trim()) return;
+    setSearching(true);
+    setSearchResults([]);
+    setReport(null);
+    setError('');
+    try {
+      const res = await fetch(`/api/analyze-institution?search=${encodeURIComponent(query)}`);
+      const data = await res.json();
+      setSearchResults(data.results || []);
+    } catch {
+      setError('Search failed');
+    }
+    setSearching(false);
+  }
+
+  async function handleAnalyze(ror: string) {
+    setLoading(true);
+    setError('');
+    setSearchResults([]);
+    try {
+      const res = await fetch(`/api/analyze-institution?ror=${ror}`);
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Analysis failed (HTTP ${res.status})`);
+      }
+      const data: InstitutionReport = await res.json();
+      setReport(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Analysis failed.');
+    }
+    setLoading(false);
+  }
+
+  return (
+    <div className="min-h-screen py-8">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-gray-900">
+            Institutional Research Visibility
+          </h1>
+          <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+            <span className="rounded-full bg-blue-100 px-3 py-1 font-medium text-blue-800">
+              Scope: Journal articles only
+            </span>
+            <span className="rounded-full bg-blue-100 px-3 py-1 font-medium text-blue-800">
+              Window: Last 90 days
+            </span>
+          </div>
+          <p className="mt-3 text-gray-600">
+            How publishers deposit metadata for your institution&apos;s journal articles — observed directly from Crossref work records. Scope and window are chosen to respect the free rate limits offered by{' '}
+            <a
+              href="https://www.crossref.org/documentation/retrieve-metadata/rest-api/tips-for-using-the-crossref-rest-api/"
+              target="_blank"
+              rel="noreferrer"
+              className="text-blue-600 hover:underline"
+            >
+              Crossref
+            </a>{' '}
+            and{' '}
+            <a
+              href="https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication"
+              target="_blank"
+              rel="noreferrer"
+              className="text-blue-600 hover:underline"
+            >
+              OpenAlex
+            </a>
+            .
+          </p>
+        </div>
+
+        <details className="mb-4 rounded-lg border border-blue-200 bg-blue-50 text-sm text-blue-900">
+          <summary className="cursor-pointer px-4 py-3 font-medium">How this analysis works</summary>
+          <div className="space-y-4 border-t border-blue-200 px-4 py-4">
+            <p>
+              This page measures <strong>what publishers deposit to Crossref</strong> for your institution&apos;s journal articles. Crossref stores what it receives from publishers — the deposit practices are the variable. The analysis uses three data sources together:
+            </p>
+
+            <div className="rounded-md border border-blue-200 bg-white p-3">
+              <p className="font-semibold text-blue-900">1. OpenAlex — for article discovery</p>
+              <p className="mt-1 text-blue-800">
+                The tool queries OpenAlex for journal articles where any author is affiliated with this institution&apos;s ROR in the last 90 days. OpenAlex aggregates affiliation signals from multiple sources (Crossref, PubMed, MAG, author pages), so it reliably identifies &quot;these are the papers that came out of your institution&quot; even when one source is incomplete.
+              </p>
+            </div>
+
+            <div className="rounded-md border border-blue-200 bg-white p-3">
+              <p className="font-semibold text-blue-900">2. Crossref — for observed publisher deposits</p>
+              <p className="mt-1 text-blue-800">
+                For every DOI OpenAlex returns at each mapped publisher, the tool fetches the actual Crossref work record and inspects it directly. Each record is counted by what it contains — affiliations, ROR IDs, funders, abstracts, licenses, ORCIDs — exactly as the publisher deposited them.
+              </p>
+            </div>
+
+            <div className="rounded-md border border-blue-200 bg-white p-3">
+              <p className="font-semibold text-blue-900">3. ROR — the interlingua</p>
+              <p className="mt-1 text-blue-800">
+                ROR IDs are the machine-readable bridge. OpenAlex asserts &quot;this paper is from institution X&quot;; the publisher&apos;s Crossref deposit may or may not include X&apos;s ROR on any author. The <strong>Inst. ROR</strong> column tests whether the publisher included <em>this institution&apos;s specific ROR</em> in the deposit — the gold-standard signal for automated institutional linking.
+              </p>
+            </div>
+
+            <div className="rounded-md bg-white p-3">
+              <p className="font-semibold text-gray-900">How the numbers are built</p>
+              <ul className="mt-1 list-disc list-inside space-y-0.5 text-gray-700">
+                <li>Gap counts are <strong>observed from each Crossref work record</strong>, not projected from publisher-wide averages.</li>
+                <li>If OpenAlex identifies a paper as institutional output but the Crossref deposit has no institutional ROR, that&apos;s counted as a gap — the affiliation exists, the publisher just didn&apos;t deposit it.</li>
+                <li>Only journal articles are inspected — no proceedings, book chapters, or peer reviews — to avoid the content-type dilution that inflates aggregate-style scores.</li>
+                <li>Publishers with fewer than 10 articles from this institution are shown but not measured (sample too small).</li>
+                <li>Articles that can&apos;t be traced to a mapped Crossref deposit are reported separately in &quot;Why N articles weren&apos;t analyzed&quot; with a per-reason breakdown.</li>
+                <li>A single extra OpenAlex count call fetches the institution&apos;s full-year journal-article output; the cost calculator uses that number to extrapolate the observed 90-day gap to an annual rate at your chosen hourly rates.</li>
+              </ul>
+            </div>
+          </div>
+        </details>
+
+        <details className="mb-4 rounded-lg border border-amber-300 bg-amber-50 text-sm text-amber-900">
+          <summary className="cursor-pointer px-4 py-3 font-semibold flex items-center gap-2">
+            <span aria-hidden="true">⚠️</span>
+            What to keep in mind while reading the report
+          </summary>
+          <ul className="space-y-2 border-t border-amber-200 px-4 py-4 text-amber-900">
+            <li>
+              <strong>Not every article can be analyzed — and every reason is a deposit gap.</strong> Some articles were never registered with Crossref (published only in an institutional repo, preprint server, or data platform); some come from publishers not yet mapped to a Crossref member ID; some have a deposit so incomplete that the publisher itself can&apos;t be identified downstream. The &quot;Why N articles weren&apos;t analyzed&quot; section below breaks these down.
+            </li>
+            <li>
+              <strong>Author attribution is permissive.</strong> A paper is treated as &quot;from this institution&quot; if any author is affiliated with it. A co-authored paper with 20 authors across 5 institutions counts once for each — the deposit may or may not actually include this institution&apos;s ROR even when the institutional link is real.
+            </li>
+            <li>
+              <strong>String affiliation without ROR is not &quot;missing&quot;.</strong> A publisher that deposits &quot;University of Oxford, Department of X&quot; as text but no ROR ID will show as <em>has affiliation</em> but <em>no ROR</em>. The attribution exists in human-readable form; machine processing is what&apos;s blocked.
+            </li>
+            <li>
+              <strong>ROR has no funder-vs-institution type flag.</strong> A single organization (Wellcome, Max Planck, NIH, etc.) holds one ROR ID that can play either role — the meaning depends on <em>where</em> the ROR appears in the deposit: in <code className="rounded bg-white/70 px-1">author.affiliation.id</code> it&apos;s an institutional signal; in <code className="rounded bg-white/70 px-1">funder.id</code> it&apos;s a funder signal. This tool currently inspects ROR only in the affiliation field. As publishers transition from the legacy Open Funder Registry to funder ROR IDs, a separate funder-ROR metric may be added.
+            </li>
+            <li>
+              <strong>Point-in-time snapshot.</strong> Publishers can and do revise deposits. Numbers here reflect the state of Crossref at the moment of analysis — don&apos;t treat them as immutable.
+            </li>
+            <li>
+              <strong>Small samples are omitted.</strong> Publishers with fewer than 10 articles from this institution are shown but not measured — too few records to draw meaningful percentages from. Counts below that threshold are for reference only.
+            </li>
+            <li>
+              <strong>Annual cost estimates are extrapolated.</strong> The hours shown per stakeholder come from the observed 90-day gap, scaled up to a year using the institution&apos;s real full-year article count. Hourly rates you enter in the cost calculator stay local to your browser.
+            </li>
+          </ul>
+        </details>
+
+        <details className="mb-6 rounded-lg border border-slate-200 bg-slate-50 text-sm text-slate-800">
+          <summary className="cursor-pointer px-4 py-3 font-medium">What each gap column means</summary>
+          <div className="space-y-4 border-t border-slate-200 px-4 py-4">
+            <ul className="space-y-2 text-slate-700">
+              <li>
+                <strong>No Affiliation</strong> — the Crossref deposit carries no author affiliation at all. Not just &quot;missing ROR&quot; — the affiliation text field itself is empty. Institutional linking from the deposit is impossible without manual publisher-site scraping.
+              </li>
+              <li>
+                <strong>No Any ROR</strong> — the deposit has affiliation text but no ROR identifier on any author. Matching still requires string parsing of &quot;Department of X, University of Y&quot; — brittle and fails for renamed departments, translated names, and multi-institution affiliations.
+              </li>
+              <li>
+                <strong>No Inst. ROR</strong> — the deposit does not include <em>this specific institution&apos;s</em> ROR on any author. This is the strictest test. A paper may have ROR IDs for other co-author institutions but not this one&apos;s. CRIS auto-ingest requires this exact match.
+              </li>
+              <li>
+                <strong>No Funder</strong> — the deposit has no funder metadata. The paper may have been funded; the funder-grant information simply wasn&apos;t transmitted. Mandate-compliance reporting (UKRI, NIH, Wellcome) falls back to manual grant-database cross-referencing.
+              </li>
+              <li>
+                <strong>No Abstract</strong> — the deposit has no abstract. Discovery tools (Semantic Scholar, OpenAlex, Elicit, Consensus) index from Crossref abstracts. Missing = less discoverable, fewer citations, weaker research impact signal.
+              </li>
+              <li>
+                <strong>No ORCID / License</strong> — similar story for author identity persistence (ORCID) and open-access verification (license). Both are schema-supported; both are deposit-practice dependent.
+              </li>
+            </ul>
+          </div>
+        </details>
+
+        <div className="mb-6 rounded-lg border bg-white p-6 shadow-sm">
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Search by institution name
+          </label>
+          <div className="flex gap-3">
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+              placeholder="e.g. University of Oxford, MIT, IISc..."
+              className="flex-1 rounded-lg border border-gray-300 px-4 py-2.5 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 outline-none"
+            />
+            <button
+              onClick={handleSearch}
+              disabled={searching}
+              className="rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {searching ? 'Searching...' : 'Search'}
+            </button>
+          </div>
+
+          {searchResults.length > 0 && (
+            <div className="mt-4 divide-y rounded-lg border">
+              {searchResults.map((r) => (
+                <button
+                  key={r.ror}
+                  onClick={() => handleAnalyze(r.ror)}
+                  className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-gray-50"
+                >
+                  <div>
+                    <span className="font-medium text-gray-900">{r.name}</span>
+                    <span className="ml-2 text-sm text-gray-500">{r.country}</span>
+                  </div>
+                  <span className="text-xs text-gray-400">ROR: {r.ror}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {loading && (
+          <div className="rounded-lg border bg-white p-12 text-center shadow-sm">
+            <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+            <p className="mt-4 text-gray-600">Fetching DOIs from OpenAlex and inspecting Crossref records...</p>
+            <p className="mt-1 text-sm text-gray-400">
+              This usually takes 20–60 seconds. Larger institutions take longer — every article is paginated through.
+            </p>
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {report && (
+          <div className="space-y-8">
+            <div className="rounded-lg border bg-white p-6 shadow-sm">
+              <h2 className="text-2xl font-bold text-gray-900">{report.institution.name}</h2>
+              <p className="mt-1 text-sm text-gray-500">
+                {report.dateRange}
+              </p>
+              <p className="mt-1 text-sm text-gray-500">
+                <strong>{report.totalArticles.toLocaleString()}</strong> journal articles total &middot;{' '}
+                <strong>{report.trackedArticles.toLocaleString()}</strong> at publishers mapped to Crossref &middot;{' '}
+                <strong>{report.measuredArticles.toLocaleString()}</strong> measured
+                {report.unmappedPublishers.length > 0 && (
+                  <> &middot; {report.unmappedPublishers.reduce((s, u) => s + u.articles, 0).toLocaleString()} at unmapped publishers</>
+                )}
+              </p>
+
+              <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+                <StatCard
+                  value={`${(100 - report.totals.institutionalRorPercent).toFixed(0)}%`}
+                  label="Missing this institution's ROR"
+                  sublabel={`${report.totals.noInstitutionalRor.toLocaleString()} articles`}
+                  color="red"
+                />
+                <StatCard
+                  value={`${(100 - report.totals.affiliationPercent).toFixed(0)}%`}
+                  label="No affiliation at all"
+                  sublabel={`${report.totals.noAffiliation.toLocaleString()} articles`}
+                  color="red"
+                />
+                <StatCard
+                  value={`${(100 - report.totals.funderPercent).toFixed(0)}%`}
+                  label="No funder metadata"
+                  sublabel={`${report.totals.noFunder.toLocaleString()} articles`}
+                  color="amber"
+                />
+                <StatCard
+                  value={`${(100 - report.totals.abstractPercent).toFixed(0)}%`}
+                  label="No abstract"
+                  sublabel={`${report.totals.noAbstract.toLocaleString()} articles`}
+                  color="amber"
+                />
+              </div>
+            </div>
+
+            <div className="rounded-lg border bg-white shadow-sm">
+              <div className="border-b px-6 py-4">
+                <h3 className="text-lg font-semibold text-gray-900">
+                  What each publisher deposited
+                </h3>
+                <p className="mt-1 text-sm text-gray-500">
+                  Percentages are observed from each publisher&apos;s actual Crossref deposits for this institution&apos;s articles. Click column headers to sort. <strong>Inst. ROR</strong> = this institution&apos;s specific ROR deposited on the paper.
+                </p>
+              </div>
+              <PublisherGapTable publishers={report.publishers} />
+            </div>
+
+            <div className="rounded-lg border bg-white shadow-sm">
+              <div className="border-b px-6 py-4">
+                <h3 className="text-lg font-semibold text-gray-900">What you can&apos;t see</h3>
+                <p className="mt-1 text-sm text-gray-500">
+                  Articles missing key metadata, sorted by largest institutional-ROR gap. Only measured publishers shown.
+                </p>
+              </div>
+              <GapSummaryTable publishers={report.publishers} />
+              <div className="border-t bg-gray-50 px-6 py-4">
+                <p className="text-sm text-gray-700">
+                  <span className="font-semibold">{(100 - report.totals.institutionalRorPercent).toFixed(1)}%</span> of measured articles were deposited by publishers without a ROR linking them to {report.institution.name}. The affiliation signal exists — OpenAlex confirms it — but it didn&apos;t make it into the deposit.
+                </p>
+              </div>
+            </div>
+
+            {report.unmappedPublishers.length > 0 && (() => {
+              const totalUnmapped = report.unmappedPublishers.reduce((s, u) => s + u.articles, 0);
+              const noMetadata = report.unmappedPublishers.filter((u) => u.category === 'no-metadata').reduce((s, u) => s + u.articles, 0);
+              const institutional = report.unmappedPublishers.filter((u) => u.category === 'institutional').reduce((s, u) => s + u.articles, 0);
+              const unmappedPub = report.unmappedPublishers.filter((u) => u.category === 'unmapped-publisher').reduce((s, u) => s + u.articles, 0);
+              const rows = [
+                {
+                  count: institutional,
+                  title: 'No Crossref DOI registered at all',
+                  desc: 'The article exists only in an institutional repository, preprint server, or data platform — the publisher never registered a DOI through Crossref. Without a deposit, there\'s nothing to inspect. Smaller publishers, regional outlets, and non-traditional venues often skip Crossref registration entirely.',
+                },
+                {
+                  count: unmappedPub,
+                  title: 'Publisher deposits exist but aren\'t mapped yet',
+                  desc: 'The publisher does deposit to Crossref, but the mapping table doesn\'t yet link their OpenAlex identity to their Crossref member ID. Fixable — new publishers get added as they surface. Check back in a future run.',
+                },
+                {
+                  count: noMetadata,
+                  title: 'Deposit too incomplete to identify the publisher',
+                  desc: 'OpenAlex attributes the article to this institution but can\'t determine who published it. This typically means the Crossref deposit was missing or skeletal enough that the publisher field couldn\'t be reconstructed — another form of deposit gap, one step removed.',
+                },
+              ].filter((r) => r.count > 0);
+              return (
+                <div className="rounded-lg border bg-white shadow-sm">
+                  <div className="border-b px-6 py-4">
+                    <h3 className="text-lg font-semibold text-gray-900">
+                      Why {totalUnmapped.toLocaleString()} articles weren&apos;t analyzed — all publisher deposit gaps
+                    </h3>
+                    <p className="mt-1 text-sm text-gray-500">
+                      Of the {report.totalArticles.toLocaleString()} articles OpenAlex attributed to {report.institution.name}, {totalUnmapped.toLocaleString()} couldn&apos;t be measured against Crossref deposits. Every reason below traces back to the same root — <strong>the publisher didn&apos;t deposit complete metadata to Crossref</strong> (or didn&apos;t deposit at all).
+                    </p>
+                  </div>
+                  <div className="divide-y divide-gray-100">
+                    {rows.map((r) => (
+                      <div key={r.title} className="px-6 py-4">
+                        <div className="flex items-start justify-between gap-4">
+                          <div>
+                            <p className="font-semibold text-gray-900">{r.title}</p>
+                            <p className="mt-1 text-sm text-gray-600">{r.desc}</p>
+                          </div>
+                          <div className="shrink-0 text-right">
+                            <p className="text-2xl font-bold text-gray-900">{r.count.toLocaleString()}</p>
+                            <p className="text-xs text-gray-500">articles</p>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="border-t bg-gray-50 px-6 py-3 text-xs text-gray-600">
+                    Every bucket above is a form of deposit gap. Not registering a DOI, depositing incomplete metadata, or skipping Crossref entirely — each leaves institutions with less signal to track their own research.
+                  </div>
+                </div>
+              );
+            })()}
+
+            <InstitutionalBlindSpots report={report} />
+
+            <StakeholderImpact report={report} />
+
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  value,
+  label,
+  sublabel,
+  color,
+}: {
+  value: string;
+  label: string;
+  sublabel: string;
+  color: 'red' | 'amber';
+}) {
+  const bg = color === 'red' ? 'bg-red-50 border-red-200' : 'bg-amber-50 border-amber-200';
+  const text = color === 'red' ? 'text-red-700' : 'text-amber-700';
+  const sub = color === 'red' ? 'text-red-600' : 'text-amber-600';
+
+  return (
+    <div className={`rounded-lg border p-4 ${bg}`}>
+      <p className={`text-2xl font-bold ${text}`}>{value}</p>
+      <p className={`text-sm font-medium ${sub}`}>{label}</p>
+      <p className="mt-1 text-xs text-gray-500">{sublabel}</p>
+    </div>
+  );
+}

--- a/apps/web/src/app/analysis/institution/page.tsx
+++ b/apps/web/src/app/analysis/institution/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { Suspense, useEffect, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import type { InstitutionReport } from '../../../lib/publisher-map';
 import { PublisherGapTable, GapSummaryTable } from '../../../components/publisher-gap-table';
 import { StakeholderImpact } from '../../../components/stakeholder-impact';
@@ -12,13 +13,43 @@ interface SearchResult {
   country: string;
 }
 
-export default function InstitutionAnalysisPage() {
+function InstitutionAnalysisPageInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const urlRor = searchParams.get('ror');
+
   const [query, setQuery] = useState('');
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [report, setReport] = useState<InstitutionReport | null>(null);
   const [loading, setLoading] = useState(false);
   const [searching, setSearching] = useState(false);
   const [error, setError] = useState('');
+  const analyzedRorRef = useRef<string | null>(null);
+
+  // Run analysis when ?ror=... is in the URL. This gives each analyzed
+  // institution a unique, shareable URL and makes pageviews show up
+  // per-institution in Vercel Analytics.
+  useEffect(() => {
+    if (!urlRor || urlRor === analyzedRorRef.current) return;
+    analyzedRorRef.current = urlRor;
+    (async () => {
+      setLoading(true);
+      setError('');
+      setSearchResults([]);
+      try {
+        const res = await fetch(`/api/analyze-institution?ror=${urlRor}`);
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.error || `Analysis failed (HTTP ${res.status})`);
+        }
+        const data: InstitutionReport = await res.json();
+        setReport(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Analysis failed.');
+      }
+      setLoading(false);
+    })();
+  }, [urlRor]);
 
   async function handleSearch() {
     if (!query.trim()) return;
@@ -36,22 +67,11 @@ export default function InstitutionAnalysisPage() {
     setSearching(false);
   }
 
-  async function handleAnalyze(ror: string) {
-    setLoading(true);
-    setError('');
-    setSearchResults([]);
-    try {
-      const res = await fetch(`/api/analyze-institution?ror=${ror}`);
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || `Analysis failed (HTTP ${res.status})`);
-      }
-      const data: InstitutionReport = await res.json();
-      setReport(data);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Analysis failed.');
-    }
-    setLoading(false);
+  function handleAnalyze(ror: string) {
+    // Push to URL — the useEffect above will kick off the analysis. This
+    // makes each institution a distinct page view and supports sharing.
+    const params = new URLSearchParams({ ror });
+    router.push(`/analysis/institution?${params.toString()}`, { scroll: false });
   }
 
   return (
@@ -405,5 +425,14 @@ function StatCard({
       <p className={`text-sm font-medium ${sub}`}>{label}</p>
       <p className="mt-1 text-xs text-gray-500">{sublabel}</p>
     </div>
+  );
+}
+
+// useSearchParams needs a Suspense boundary in Next.js App Router.
+export default function InstitutionAnalysisPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen" />}>
+      <InstitutionAnalysisPageInner />
+    </Suspense>
   );
 }

--- a/apps/web/src/app/api/analyze-institution/route.ts
+++ b/apps/web/src/app/api/analyze-institution/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { analyzeInstitution, searchInstitutions } from '../../../lib/analyze-institution';
+
+export const maxDuration = 60;
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const ror = searchParams.get('ror');
+  const search = searchParams.get('search');
+  const daysRaw = searchParams.get('days');
+  const days = daysRaw ? Math.max(7, Math.min(365, parseInt(daysRaw, 10))) : 90;
+
+  if (search) {
+    try {
+      const results = await searchInstitutions(search);
+      return NextResponse.json({ results });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Search failed';
+      return NextResponse.json({ error: message }, { status: 502 });
+    }
+  }
+
+  if (!ror) {
+    return NextResponse.json(
+      { error: 'Provide ?ror=<ror_id> or ?search=<institution name>' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const report = await analyzeInstitution(ror, days);
+    return NextResponse.json(report);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Analysis failed';
+    const isRateLimit = /429|rate/i.test(message);
+    return NextResponse.json(
+      {
+        error: isRateLimit
+          ? 'OpenAlex or Crossref is rate-limiting. Wait a moment and retry.'
+          : message,
+      },
+      { status: isRateLimit ? 429 : 500 }
+    );
+  }
+}

--- a/apps/web/src/components/institutional-blind-spots.tsx
+++ b/apps/web/src/components/institutional-blind-spots.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import type { InstitutionReport } from '../lib/publisher-map';
+
+interface BlindSpot {
+  question: string;
+  answer: string;
+  dataNeeded: string;
+  currentState: string;
+  articlesBlind: number;
+  percentBlind: number;
+  decision: string;
+}
+
+function buildBlindSpots(report: InstitutionReport): BlindSpot[] {
+  const { totals, measuredArticles, institution, publishers } = report;
+  const denom = measuredArticles || 1;
+  const pctNoAffil = (totals.noAffiliation / denom) * 100;
+  const pctNoFunder = (totals.noFunder / denom) * 100;
+  const pctNoInstRor = (totals.noInstitutionalRor / denom) * 100;
+  const pctNoAbstract = (totals.noAbstract / denom) * 100;
+
+  const measured = publishers.filter((p) => p.measured);
+  const worstAffil = [...measured].sort((a, b) => a.coverage.affiliations - b.coverage.affiliations)[0];
+  const bestAffil = [...measured].sort((a, b) => b.coverage.affiliations - a.coverage.affiliations)[0];
+  const biggestPublisher = measured[0]; // already sorted by article count
+
+  return [
+    {
+      question: `How many articles did ${institution.name} publish last year?`,
+      answer: `You don't know — not from the deposits.`,
+      dataNeeded: 'Affiliation metadata linking articles to your institution',
+      currentState: `${pctNoAffil.toFixed(0)}% of your tracked articles have no institutional affiliation deposited by publishers to Crossref. You can find ${(100 - pctNoAffil).toFixed(0)}% of your output. The rest requires manual searching.`,
+      articlesBlind: totals.noAffiliation,
+      percentBlind: pctNoAffil,
+      decision: 'Require affiliation deposits in every publishing agreement. No affiliation, no payment.',
+    },
+    {
+      question: `Which publishers deliver the most value?`,
+      answer: `You can't compare — the data isn't comparable.`,
+      dataNeeded: 'Consistent metadata across all publishers',
+      currentState: `${bestAffil?.name} deposits ${bestAffil?.coverage.affiliations.toFixed(0)}% affiliations. ${worstAffil?.name} deposits ${worstAffil?.coverage.affiliations.toFixed(0)}%. You're comparing complete data against empty data. Any cross-publisher analysis is misleading.`,
+      articlesBlind: totals.noAffiliation,
+      percentBlind: pctNoAffil,
+      decision: 'Before renewing any agreement, check what the publisher actually deposits. Use this as a baseline for the next contract.',
+    },
+    {
+      question: `Are your funders' mandates being met?`,
+      answer: `You can verify ${(100 - pctNoFunder).toFixed(0)}% at best.`,
+      dataNeeded: 'Funder metadata with grant numbers on every funded article',
+      currentState: `${totals.noFunder.toLocaleString()} articles have no funder metadata deposited by publishers to Crossref. When UKRI or Wellcome asks "did your researchers comply?", you can't answer from metadata alone. You need manual cross-referencing against grant databases.`,
+      articlesBlind: totals.noFunder,
+      percentBlind: pctNoFunder,
+      decision: 'Work with your grants office to require funder DOI deposits as a condition of grant reporting.',
+    },
+    {
+      question: `Can your CRIS system automatically ingest your publications?`,
+      answer: `For ${pctNoInstRor.toFixed(0)}% of articles — no.`,
+      dataNeeded: `This institution's ROR (${institution.ror}) deposited in the affiliation metadata`,
+      currentState: `${totals.noInstitutionalRor.toLocaleString()} articles had no ROR for ${institution.name} on any author. CRIS auto-ingest relies on this exact identifier. Fallback: manual self-deposit or paid matching services — both lossy.`,
+      articlesBlind: totals.noInstitutionalRor,
+      percentBlind: pctNoInstRor,
+      decision: 'Require publishers to include your ROR on every affiliation. The Crossref schema supports it; adoption is the bottleneck.',
+    },
+    {
+      question: `Is your research discoverable by AI?`,
+      answer: `${totals.noAbstract.toLocaleString()} articles are harder to find.`,
+      dataNeeded: 'Abstracts deposited to Crossref for indexing by discovery tools',
+      currentState: `Semantic Scholar, OpenAlex, Elicit, Consensus — the next generation of research tools — depend on abstracts that publishers deposit to Crossref. ${pctNoAbstract.toFixed(0)}% of your articles have none. ${biggestPublisher?.name} (your largest publisher with ${biggestPublisher?.articles.toLocaleString()} articles) deposits abstracts for ${biggestPublisher?.coverage.abstracts.toFixed(0)}% of them.`,
+      articlesBlind: totals.noAbstract,
+      percentBlind: pctNoAbstract,
+      decision: 'Prioritize publishers who deposit abstracts. Abstract coverage directly affects your researchers\' visibility.',
+    },
+    {
+      question: `What is your actual open access output?`,
+      answer: `License metadata tells part of the story — but not all of it.`,
+      dataNeeded: 'Complete license metadata on every article',
+      currentState: `Without consistent license metadata, you can't programmatically count how many articles are truly open access. You can't report OA percentages to your board, to government, or to rankings agencies with confidence.`,
+      articlesBlind: 0,
+      percentBlind: 0,
+      decision: 'Every OA article must have CC license metadata in Crossref. If you\'re paying for open access, the metadata must prove it.',
+    },
+  ];
+}
+
+export function InstitutionalBlindSpots({ report }: { report: InstitutionReport }) {
+  const spots = buildBlindSpots(report);
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900">
+          What {report.institution.name} can&apos;t see
+        </h3>
+        <p className="mt-1 text-sm text-gray-500">
+          Six questions every institution should be able to answer from metadata alone. Today, most can&apos;t — because publishers don&apos;t deposit complete metadata, even though the Crossref schema supports every field below.
+        </p>
+      </div>
+
+      {spots.map((spot, i) => (
+        <div key={i} className="rounded-lg border bg-white shadow-sm overflow-hidden">
+          {/* Question header */}
+          <div className="border-b bg-gray-900 px-5 py-4">
+            <p className="text-white font-medium">{spot.question}</p>
+          </div>
+
+          <div className="p-5 space-y-4">
+            {/* Answer */}
+            <div>
+              <p className="text-lg font-semibold text-red-700">{spot.answer}</p>
+            </div>
+
+            {/* Current state */}
+            <div className="rounded-lg bg-gray-50 p-4">
+              <p className="text-sm text-gray-700 leading-relaxed">{spot.currentState}</p>
+            </div>
+
+            {/* Visual bar */}
+            {spot.articlesBlind > 0 && (
+              <div>
+                <div className="flex justify-between text-xs text-gray-500 mb-1">
+                  <span>Visible ({(100 - spot.percentBlind).toFixed(0)}%)</span>
+                  <span>Blind ({spot.percentBlind.toFixed(0)}%)</span>
+                </div>
+                <div className="h-3 rounded-full bg-gray-200 overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-emerald-500"
+                    style={{ width: `${100 - spot.percentBlind}%` }}
+                  />
+                </div>
+                <p className="mt-1 text-xs text-gray-400">
+                  {spot.articlesBlind.toLocaleString()} articles with this gap in publisher deposits
+                </p>
+              </div>
+            )}
+
+            {/* The decision */}
+            <div className="rounded-lg border-l-4 border-blue-400 bg-blue-50 px-4 py-3">
+              <p className="text-xs font-medium text-blue-600 uppercase tracking-wider mb-1">The decision</p>
+              <p className="text-sm text-blue-900">{spot.decision}</p>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/publisher-gap-table.tsx
+++ b/apps/web/src/components/publisher-gap-table.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import type { PublisherGap } from '../lib/publisher-map';
+import { useState } from 'react';
+
+function coverageColor(pct: number): string {
+  if (pct >= 80) return 'bg-emerald-100 text-emerald-800';
+  if (pct >= 50) return 'bg-yellow-100 text-yellow-800';
+  if (pct >= 20) return 'bg-amber-100 text-amber-800';
+  return 'bg-red-100 text-red-800';
+}
+
+function gapColor(pct: number): string {
+  if (pct >= 80) return 'text-red-700 font-semibold';
+  if (pct >= 50) return 'text-amber-700';
+  return 'text-gray-600';
+}
+
+type SortField = 'articles' | 'affiliations' | 'rorIds' | 'instRor' | 'funders' | 'abstracts' | 'orcids';
+
+export function PublisherGapTable({ publishers }: { publishers: PublisherGap[] }) {
+  const [sortField, setSortField] = useState<SortField>('articles');
+  const [sortDesc, setSortDesc] = useState(true);
+
+  const valueFor = (p: PublisherGap, f: SortField): number => {
+    if (f === 'articles') return p.articles;
+    if (f === 'instRor') return p.measured && p.articles > 0 ? (p.institutionalRor / p.articles) * 100 : -1;
+    return p.measured ? p.coverage[f] : -1;
+  };
+
+  const sorted = [...publishers].sort((a, b) => {
+    const av = valueFor(a, sortField);
+    const bv = valueFor(b, sortField);
+    return sortDesc ? bv - av : av - bv;
+  });
+
+  function handleSort(field: SortField) {
+    if (sortField === field) setSortDesc(!sortDesc);
+    else { setSortField(field); setSortDesc(true); }
+  }
+
+  const arrow = (field: SortField) =>
+    sortField === field ? (sortDesc ? ' ↓' : ' ↑') : '';
+
+  const th = (field: SortField, label: string, help?: string) => (
+    <th
+      className="px-3 py-3 text-right font-medium text-gray-700 cursor-pointer hover:text-gray-900"
+      onClick={() => handleSort(field)}
+      title={help}
+    >
+      {label}{arrow(field)}
+    </th>
+  );
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200 text-sm">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-3 text-left font-medium text-gray-700">Publisher</th>
+            {th('articles', 'Articles')}
+            {th('affiliations', 'Affiliation', 'Any author affiliation present')}
+            {th('rorIds', 'Any ROR', 'Any ROR ID in any affiliation')}
+            {th('instRor', 'Inst. ROR', 'THIS institution\'s ROR on the paper')}
+            {th('funders', 'Funder')}
+            {th('abstracts', 'Abstract')}
+            {th('orcids', 'ORCID')}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200 bg-white">
+          {sorted.map((p) => {
+            if (!p.measured) {
+              return (
+                <tr key={p.crossrefId} className="bg-gray-50/50">
+                  <td className="px-3 py-2.5 font-medium text-gray-500">
+                    <a href={`/member/${p.crossrefId}`} className="hover:text-blue-600 hover:underline">
+                      {p.name}
+                    </a>
+                  </td>
+                  <td className="px-3 py-2.5 text-right text-gray-500">{p.articles.toLocaleString()}</td>
+                  <td colSpan={6} className="px-3 py-2.5 text-right text-xs text-gray-400 italic">
+                    sample too small to measure
+                  </td>
+                </tr>
+              );
+            }
+            const instRorPct = (p.institutionalRor / p.articles) * 100;
+            return (
+              <tr key={p.crossrefId} className="hover:bg-gray-50">
+                <td className="px-3 py-2.5 font-medium text-gray-900">
+                  <a href={`/member/${p.crossrefId}`} className="hover:text-blue-600 hover:underline">
+                    {p.name}
+                  </a>
+                </td>
+                <td className="px-3 py-2.5 text-right text-gray-700">{p.articles.toLocaleString()}</td>
+                <td className="px-3 py-2.5 text-right">
+                  <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${coverageColor(p.coverage.affiliations)}`}>
+                    {p.coverage.affiliations.toFixed(0)}%
+                  </span>
+                </td>
+                <td className="px-3 py-2.5 text-right">
+                  <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${coverageColor(p.coverage.rorIds)}`}>
+                    {p.coverage.rorIds.toFixed(0)}%
+                  </span>
+                </td>
+                <td className="px-3 py-2.5 text-right">
+                  <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${coverageColor(instRorPct)}`}>
+                    {instRorPct.toFixed(0)}%
+                  </span>
+                </td>
+                <td className="px-3 py-2.5 text-right">
+                  <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${coverageColor(p.coverage.funders)}`}>
+                    {p.coverage.funders.toFixed(0)}%
+                  </span>
+                </td>
+                <td className="px-3 py-2.5 text-right">
+                  <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${coverageColor(p.coverage.abstracts)}`}>
+                    {p.coverage.abstracts.toFixed(0)}%
+                  </span>
+                </td>
+                <td className="px-3 py-2.5 text-right">
+                  <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${coverageColor(p.coverage.orcids)}`}>
+                    {p.coverage.orcids.toFixed(0)}%
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function GapSummaryTable({ publishers }: { publishers: PublisherGap[] }) {
+  const measured = publishers.filter((p) => p.measured);
+  const sorted = [...measured].sort((a, b) => b.gap.noInstitutionalRor - a.gap.noInstitutionalRor);
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200 text-sm">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-3 text-left font-medium text-gray-700">Publisher</th>
+            <th className="px-3 py-3 text-right font-medium text-gray-700">Articles</th>
+            <th className="px-3 py-3 text-right font-medium text-gray-700" title="Articles where this institution's ROR wasn't deposited">No Inst. ROR</th>
+            <th className="px-3 py-3 text-right font-medium text-gray-700">No Affiliation</th>
+            <th className="px-3 py-3 text-right font-medium text-gray-700">No Funder</th>
+            <th className="px-3 py-3 text-right font-medium text-gray-700">No Abstract</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200 bg-white">
+          {sorted.map((p) => {
+            const instRorPct = (p.gap.noInstitutionalRor / p.articles) * 100;
+            const afPct = (p.gap.noAffiliation / p.articles) * 100;
+            const fuPct = (p.gap.noFunder / p.articles) * 100;
+            const abPct = (p.gap.noAbstract / p.articles) * 100;
+            return (
+              <tr key={p.crossrefId} className="hover:bg-gray-50">
+                <td className="px-3 py-2.5 font-medium text-gray-900">{p.name}</td>
+                <td className="px-3 py-2.5 text-right text-gray-700">{p.articles.toLocaleString()}</td>
+                <td className={`px-3 py-2.5 text-right ${gapColor(instRorPct)}`}>
+                  {p.gap.noInstitutionalRor.toLocaleString()} ({instRorPct.toFixed(0)}%)
+                </td>
+                <td className={`px-3 py-2.5 text-right ${gapColor(afPct)}`}>
+                  {p.gap.noAffiliation.toLocaleString()} ({afPct.toFixed(0)}%)
+                </td>
+                <td className={`px-3 py-2.5 text-right ${gapColor(fuPct)}`}>
+                  {p.gap.noFunder.toLocaleString()} ({fuPct.toFixed(0)}%)
+                </td>
+                <td className={`px-3 py-2.5 text-right ${gapColor(abPct)}`}>
+                  {p.gap.noAbstract.toLocaleString()} ({abPct.toFixed(0)}%)
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/components/stakeholder-impact.tsx
+++ b/apps/web/src/components/stakeholder-impact.tsx
@@ -1,0 +1,337 @@
+'use client';
+
+import { useState } from 'react';
+import type { InstitutionReport } from '../lib/publisher-map';
+
+interface StakeholderFriction {
+  key: 'library' | 'researchOffice' | 'cris' | 'researchers';
+  stakeholder: string;
+  role: string;
+  metadataGap: string;
+  articlesAffected: number;
+  minutesPerArticle: number | null;
+  consequence: string;
+}
+
+function buildFrictions(report: InstitutionReport): StakeholderFriction[] {
+  const { totals } = report;
+  return [
+    {
+      key: 'library',
+      stakeholder: 'Library',
+      role: 'Identifying the institution\'s output',
+      metadataGap: 'Institution\'s ROR not deposited on the paper',
+      articlesAffected: totals.noInstitutionalRor,
+      minutesPerArticle: 5,
+      consequence: 'Library staff can\'t auto-discover these articles as institutional output from Crossref. Identification requires manual publisher-site searching or expensive third-party matching.',
+    },
+    {
+      key: 'researchOffice',
+      stakeholder: 'Research Office',
+      role: 'Funder mandate compliance',
+      metadataGap: 'No funder metadata in Crossref deposit',
+      articlesAffected: totals.noFunder,
+      minutesPerArticle: 15,
+      consequence: 'When UKRI, Wellcome, NIH ask "did your researchers comply with OA and funder mandates?" — the answer requires cross-referencing grant databases manually, because the funder field wasn\'t deposited.',
+    },
+    {
+      key: 'cris',
+      stakeholder: 'CRIS / Repository',
+      role: 'Automated institutional ingest',
+      metadataGap: 'No ROR linking affiliations to institutions',
+      articlesAffected: totals.noInstitutionalRor,
+      minutesPerArticle: null,
+      consequence: 'CRIS systems depend on ROR to auto-ingest the institution\'s publications. Without it, the workflow falls back to self-deposit by researchers or paid matching services — both incomplete.',
+    },
+    {
+      key: 'researchers',
+      stakeholder: 'Researchers',
+      role: 'Discoverability by AI tools',
+      metadataGap: 'No abstract deposited to Crossref',
+      articlesAffected: totals.noAbstract,
+      minutesPerArticle: null,
+      consequence: 'Semantic Scholar, OpenAlex, Elicit, Consensus — the tools researchers increasingly use for discovery — depend on Crossref abstracts. Missing abstracts mean the paper is harder to find, harder to cite.',
+    },
+  ];
+}
+
+const STAKEHOLDER_STYLES: Record<string, { bg: string; border: string; text: string }> = {
+  Library: { bg: 'bg-blue-50', border: 'border-blue-200', text: 'text-blue-800' },
+  'Research Office': { bg: 'bg-purple-50', border: 'border-purple-200', text: 'text-purple-800' },
+  'CRIS / Repository': { bg: 'bg-green-50', border: 'border-green-200', text: 'text-green-800' },
+  Researchers: { bg: 'bg-amber-50', border: 'border-amber-200', text: 'text-amber-800' },
+};
+
+interface Rates {
+  currency: string;
+  library: number | null;
+  researchOffice: number | null;
+}
+
+function formatCost(amount: number, currency: string): string {
+  if (amount >= 1_000_000) return `${currency}${(amount / 1_000_000).toFixed(1)}M`;
+  if (amount >= 1_000) return `${currency}${(amount / 1_000).toFixed(0)}K`;
+  return `${currency}${Math.round(amount).toLocaleString()}`;
+}
+
+function RateCalculator({
+  rates,
+  setRates,
+  libraryHours,
+  researchOfficeHours,
+  annualArticleCount,
+  windowArticles,
+  institutionName,
+}: {
+  rates: Rates;
+  setRates: (r: Rates) => void;
+  libraryHours: number; // already annualised
+  researchOfficeHours: number; // already annualised
+  annualArticleCount: number;
+  windowArticles: number;
+  institutionName: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const libCost = rates.library && rates.library > 0 ? libraryHours * rates.library : 0;
+  const roCost = rates.researchOffice && rates.researchOffice > 0 ? researchOfficeHours * rates.researchOffice : 0;
+  const totalCost = libCost + roCost;
+  const hasRates = (rates.library && rates.library > 0) || (rates.researchOffice && rates.researchOffice > 0);
+
+  const usingRealAnnual = annualArticleCount > 0 && windowArticles > 0;
+
+  return (
+    <div className="fixed bottom-6 right-6 z-50">
+      {!open && (
+        <button
+          onClick={() => setOpen(true)}
+          className="rounded-full bg-gray-900 px-4 py-3 text-sm font-medium text-white shadow-lg hover:bg-gray-800"
+        >
+          {hasRates ? `Total: ${formatCost(totalCost, rates.currency)}` : 'Add cost estimates'}
+        </button>
+      )}
+      {open && (
+        <div className="w-80 rounded-xl border border-gray-200 bg-white p-4 shadow-xl">
+          <div className="flex items-center justify-between mb-3">
+            <p className="font-semibold text-gray-900 text-sm">Cost estimates</p>
+            <button
+              onClick={() => setOpen(false)}
+              className="text-gray-400 hover:text-gray-600 text-lg leading-none"
+              aria-label="Close"
+            >
+              ×
+            </button>
+          </div>
+          <p className="text-xs text-gray-500 mb-3">
+            Plug in your institution&apos;s hourly rates to see the <strong>annual</strong> cost of manual work. Rates stay in your browser — nothing is sent anywhere.
+          </p>
+
+          {usingRealAnnual && (
+            <div className="mb-3 rounded-md bg-blue-50 border border-blue-100 px-3 py-2 text-xs text-blue-900">
+              {institutionName} published{' '}
+              <strong>{annualArticleCount.toLocaleString()}</strong> journal articles in the last year
+              (vs {windowArticles.toLocaleString()} in the 90-day sample). Hours are scaled up from the
+              observed 90-day gap rate to annual.
+            </div>
+          )}
+
+          <label className="block text-xs font-medium text-gray-700 mb-1">Currency</label>
+          <select
+            value={rates.currency}
+            onChange={(e) => setRates({ ...rates, currency: e.target.value })}
+            className="mb-3 w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm bg-white"
+          >
+            <option value="$">USD ($)</option>
+            <option value="€">EUR (€)</option>
+            <option value="£">GBP (£)</option>
+            <option value="₹">INR (₹)</option>
+            <option value="A$">AUD (A$)</option>
+            <option value="C$">CAD (C$)</option>
+            <option value="CHF ">CHF</option>
+            <option value="¥">JPY (¥)</option>
+            <option value="CN¥">CNY (CN¥)</option>
+            <option value="S$">SGD (S$)</option>
+            <option value="HK$">HKD (HK$)</option>
+            <option value="NZ$">NZD (NZ$)</option>
+            <option value="R$">BRL (R$)</option>
+            <option value="R">ZAR (R)</option>
+            <option value="kr ">SEK (kr)</option>
+          </select>
+
+          <label className="block text-xs font-medium text-gray-700 mb-1">Library staff / hr</label>
+          <input
+            type="number"
+            min="0"
+            value={rates.library ?? ''}
+            onChange={(e) => setRates({ ...rates, library: e.target.value ? Number(e.target.value) : null })}
+            placeholder="e.g. 35"
+            className="mb-3 w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm"
+          />
+
+          <label className="block text-xs font-medium text-gray-700 mb-1">Research officer / hr</label>
+          <input
+            type="number"
+            min="0"
+            value={rates.researchOffice ?? ''}
+            onChange={(e) => setRates({ ...rates, researchOffice: e.target.value ? Number(e.target.value) : null })}
+            placeholder="e.g. 45"
+            className="mb-3 w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm"
+          />
+
+          {hasRates && (
+            <div className="mb-3 rounded-md border border-gray-200 bg-gray-50 p-3">
+              <p className="text-xs text-gray-500 mb-1">Annual cost estimate</p>
+              <div className="space-y-1 text-xs text-gray-700">
+                {rates.library && rates.library > 0 && (
+                  <div className="flex justify-between">
+                    <span>Library ({libraryHours.toLocaleString()} hrs/yr × {rates.currency}{rates.library})</span>
+                    <span className="font-medium">{formatCost(libCost, rates.currency)}</span>
+                  </div>
+                )}
+                {rates.researchOffice && rates.researchOffice > 0 && (
+                  <div className="flex justify-between">
+                    <span>Research Office ({researchOfficeHours.toLocaleString()} hrs/yr × {rates.currency}{rates.researchOffice})</span>
+                    <span className="font-medium">{formatCost(roCost, rates.currency)}</span>
+                  </div>
+                )}
+                <div className="flex justify-between border-t pt-1 mt-1 text-sm font-semibold text-gray-900">
+                  <span>Total / year</span>
+                  <span>{formatCost(totalCost, rates.currency)}</span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <button
+            onClick={() => setRates({ currency: '$', library: null, researchOffice: null })}
+            className="w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-100"
+          >
+            Clear rates
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function StakeholderImpact({ report }: { report: InstitutionReport }) {
+  const [rates, setRates] = useState<Rates>({ currency: '$', library: null, researchOffice: null });
+  const frictions = buildFrictions(report);
+
+  function rateForKey(key: StakeholderFriction['key']): number | null {
+    if (key === 'library') return rates.library;
+    if (key === 'researchOffice') return rates.researchOffice;
+    return null;
+  }
+
+  const libraryFriction = frictions.find((f) => f.key === 'library');
+  const researchOfficeFriction = frictions.find((f) => f.key === 'researchOffice');
+  const libraryHours = libraryFriction?.minutesPerArticle
+    ? Math.round((libraryFriction.articlesAffected * libraryFriction.minutesPerArticle) / 60)
+    : 0;
+  const researchOfficeHours = researchOfficeFriction?.minutesPerArticle
+    ? Math.round((researchOfficeFriction.articlesAffected * researchOfficeFriction.minutesPerArticle) / 60)
+    : 0;
+
+  // Extrapolate observed 90-day metrics to an annual scale using the
+  // institution's actual 1-year OpenAlex count. Ratio is computed from real
+  // data, not a flat 4x, so it reflects the institution's true output.
+  const annualMultiplier =
+    report.annualArticleCount > 0 && report.totalArticles > 0
+      ? report.annualArticleCount / report.totalArticles
+      : 365 / (report.windowDays || 90);
+
+  const libraryHoursAnnual = Math.round(libraryHours * annualMultiplier);
+  const researchOfficeHoursAnnual = Math.round(researchOfficeHours * annualMultiplier);
+
+  const libCost = rates.library && rates.library > 0 ? libraryHoursAnnual * rates.library : 0;
+  const roCost = rates.researchOffice && rates.researchOffice > 0 ? researchOfficeHoursAnnual * rates.researchOffice : 0;
+  const totalCost = libCost + roCost;
+  const hasRates = libCost > 0 || roCost > 0;
+
+  return (
+    <>
+      <div className="space-y-5">
+        <div className="rounded-lg border bg-white p-6 shadow-sm">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900">
+                Where incomplete deposits create friction
+              </h3>
+              <p className="mt-1 text-sm text-gray-500">
+                Each stakeholder hits the same missing publisher-deposited metadata in a different workflow. Article counts are <strong>observed</strong> for {report.institution.name} across measured publishers — not projections.
+              </p>
+            </div>
+            {hasRates && (
+              <div className="shrink-0 rounded-lg border border-gray-900 bg-gray-900 px-4 py-3 text-right">
+                <p className="text-xs font-medium uppercase tracking-wide text-gray-300">Annual cost estimate</p>
+                <p className="text-2xl font-bold text-white">{formatCost(totalCost, rates.currency)}</p>
+                <p className="text-xs text-gray-400 mt-0.5">extrapolated from 90-day sample at your rates</p>
+              </div>
+            )}
+          </div>
+          <div className="mt-4 rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900">
+            <span aria-hidden="true" className="mr-1">⚠️</span>
+            <strong>Time estimates</strong> (5 min, 15 min) are illustrative — rough midpoints from documented library and research-office workflows. They convey <em>scale</em> of manual work, not precise cost. The article counts themselves are exact. Use the &quot;Add cost estimates&quot; panel (bottom right) to plug in your own hourly rates.
+          </div>
+        </div>
+
+        {frictions.map((f) => {
+          const style = STAKEHOLDER_STYLES[f.stakeholder] ?? STAKEHOLDER_STYLES.Library;
+          const hours = f.minutesPerArticle !== null
+            ? Math.round((f.articlesAffected * f.minutesPerArticle) / 60)
+            : null;
+          const rate = rateForKey(f.key);
+          const cost = hours !== null && rate !== null && rate > 0 ? hours * rate : null;
+
+          return (
+            <div key={f.stakeholder} className={`rounded-lg border ${style.border} ${style.bg} p-5`}>
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h4 className={`font-semibold ${style.text}`}>{f.stakeholder}</h4>
+                  <p className="text-sm text-gray-600">{f.role}</p>
+                </div>
+                <div className="text-right">
+                  <p className={`text-xl font-bold ${style.text}`}>
+                    {f.articlesAffected.toLocaleString()}
+                  </p>
+                  <p className="text-xs text-gray-500">articles affected</p>
+                </div>
+              </div>
+
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+                <span className="rounded bg-white/70 px-2 py-1 font-medium text-gray-700">
+                  Gap: {f.metadataGap}
+                </span>
+                {hours !== null && f.minutesPerArticle !== null && (
+                  <span className="text-gray-500">
+                    ≈ {f.minutesPerArticle} min × {f.articlesAffected.toLocaleString()} ={' '}
+                    <strong>{hours.toLocaleString()} hrs</strong>
+                    {cost !== null && (
+                      <>
+                        {' '}× {rates.currency}{rate}/hr ={' '}
+                        <strong className={style.text}>{formatCost(cost, rates.currency)}</strong>
+                      </>
+                    )}
+                  </span>
+                )}
+              </div>
+
+              <p className="mt-3 text-sm text-gray-700 leading-relaxed">{f.consequence}</p>
+            </div>
+          );
+        })}
+      </div>
+
+      <RateCalculator
+        rates={rates}
+        setRates={setRates}
+        libraryHours={libraryHoursAnnual}
+        researchOfficeHours={researchOfficeHoursAnnual}
+        annualArticleCount={report.annualArticleCount}
+        windowArticles={report.totalArticles}
+        institutionName={report.institution.name}
+      />
+    </>
+  );
+}

--- a/apps/web/src/lib/analyze-institution.ts
+++ b/apps/web/src/lib/analyze-institution.ts
@@ -1,0 +1,579 @@
+/**
+ * Institutional research visibility analysis.
+ *
+ * For a given institution (ROR) over the last N days:
+ *   1. Enumerate the institution's journal articles from OpenAlex, grouped by publisher
+ *   2. For each publisher we can map to a Crossref member ID, batch-fetch the actual
+ *      Crossref work records and inspect each one for metadata presence.
+ *
+ * Gaps are OBSERVED (counted from real Crossref records), not projected from
+ * publisher-wide aggregate coverage. Publishers we can't map to a Crossref member
+ * are listed separately so their output is not silently dropped.
+ */
+
+import {
+  PUBLISHER_MAP,
+  type InstitutionReport,
+  type PublisherGap,
+  type UnmappedPublisher,
+} from './publisher-map';
+
+const OPENALEX_BASE = 'https://api.openalex.org';
+const CROSSREF_BASE = 'https://api.crossref.org';
+const MAILTO = process.env.CROSSREF_MAILTO || 'varma2friend@gmail.com';
+
+const WINDOW_DAYS = 90;
+const MIN_SAMPLE_SIZE = 10;
+const DOI_BATCH_SIZE = 40;
+const CROSSREF_CONCURRENCY = 5;
+const OPENALEX_CONCURRENCY = 5;
+const OPENALEX_PAGE_SIZE = 200;
+const CONTENT_TYPE_FILTER = 'type:article'; // OpenAlex
+const CROSSREF_TYPE_FILTER = 'type:journal-article';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function fetchJson<T>(url: string, retries = 4): Promise<T> {
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      const res = await fetch(url, {
+        headers: { 'User-Agent': `nexus-score/0.2.0 (mailto:${MAILTO})` },
+      });
+      if (res.status === 429 || res.status >= 500) {
+        await sleep(Math.pow(2, attempt) * 500);
+        lastError = new Error(`HTTP ${res.status}`);
+        continue;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status} ${url.slice(0, 120)}`);
+      return res.json() as Promise<T>;
+    } catch (err) {
+      // network errors (connection reset, timeout) — retry with backoff
+      lastError = err;
+      await sleep(Math.pow(2, attempt) * 500);
+    }
+  }
+  throw new Error(
+    `Failed after ${retries} retries: ${url.slice(0, 120)} (last: ${String(lastError).slice(0, 80)})`
+  );
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  async function run() {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      results[i] = await worker(items[i], i);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, run));
+  return results;
+}
+
+function getDateWindow(days: number): { fromDate: string; dateLabel: string } {
+  const now = new Date();
+  const start = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+  const toISO = (d: Date) => d.toISOString().split('T')[0];
+  return {
+    fromDate: toISO(start),
+    dateLabel: `${toISO(start)} to ${toISO(now)} (last ${days} days)`,
+  };
+}
+
+function normalizeDoi(doi: string | null | undefined): string | null {
+  if (!doi) return null;
+  return doi.replace(/^https?:\/\/(dx\.)?doi\.org\//i, '').toLowerCase();
+}
+
+function normalizeRor(ror: string): string {
+  return ror.replace(/^https?:\/\/ror\.org\//i, '').toLowerCase();
+}
+
+interface OpenAlexInstitution {
+  id: string;
+  display_name: string;
+  ror: string;
+  country_code: string;
+}
+
+interface OpenAlexInstitutionSearch {
+  results: OpenAlexInstitution[];
+}
+
+export async function searchInstitutions(
+  query: string
+): Promise<Array<{ name: string; ror: string; country: string }>> {
+  const url = `${OPENALEX_BASE}/institutions?search=${encodeURIComponent(query)}&per_page=10&mailto=${MAILTO}`;
+  const data = await fetchJson<OpenAlexInstitutionSearch>(url);
+  return data.results.map((inst) => ({
+    name: inst.display_name,
+    ror: normalizeRor(inst.ror || ''),
+    country: inst.country_code || '',
+  }));
+}
+
+async function getInstitutionInfo(
+  ror: string
+): Promise<{ name: string; country: string }> {
+  const url = `${OPENALEX_BASE}/institutions/ror:${ror}?mailto=${MAILTO}`;
+  const data = await fetchJson<{ display_name: string; country_code: string }>(url);
+  return { name: data.display_name, country: data.country_code || '' };
+}
+
+/**
+ * Cheap one-off count query for the institution's full-year journal-article
+ * output. Used in the UI to annualise cost estimates computed from the 90-day
+ * sample without requiring a full-year analysis.
+ */
+async function fetchAnnualArticleCount(ror: string): Promise<number> {
+  const yearAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .split('T')[0];
+  const params = new URLSearchParams({
+    filter: `authorships.institutions.ror:https://ror.org/${ror},from_publication_date:${yearAgo},${CONTENT_TYPE_FILTER}`,
+    per_page: '1',
+    select: 'id',
+    mailto: MAILTO,
+  });
+  try {
+    const data = await fetchJson<{ meta: { count: number } }>(
+      `${OPENALEX_BASE}/works?${params.toString()}`
+    );
+    return data.meta.count;
+  } catch {
+    return 0; // non-fatal; annualisation falls back to raw 90-day numbers
+  }
+}
+
+interface OpenAlexDoiWork {
+  doi: string | null;
+}
+
+interface OpenAlexDoiResponse {
+  meta: { count: number; next_cursor: string | null };
+  results: OpenAlexDoiWork[];
+}
+
+interface OpenAlexGroupResponse {
+  meta: { count: number };
+  group_by: Array<{ key: string; key_display_name: string; count: number }>;
+}
+
+/**
+ * Two-phase DOI fetch:
+ *   1. One group_by call enumerates publishers with counts.
+ *   2. For each publisher we can map to a Crossref member, fetch DOIs in parallel
+ *      with a filter that includes only that publisher's OpenAlex lineage IDs
+ *      (select=doi to minimise payload). Unmapped publishers are retained from
+ *      the group_by counts without fetching DOIs.
+ */
+async function fetchInstitutionDOIs(
+  ror: string,
+  fromDate: string
+): Promise<{
+  totalArticles: number;
+  mapped: Map<number, { name: string; dois: string[] }>;
+  unmapped: Map<string, { name: string; count: number }>;
+}> {
+  const baseFilter = `authorships.institutions.ror:https://ror.org/${ror},from_publication_date:${fromDate},${CONTENT_TYPE_FILTER}`;
+
+  // Phase 1: enumerate publishers via group_by=host_organization (singular, not lineage).
+  // Lineage returns one group per ancestor of each work, which double-counts works
+  // published by a child entity under its parent (e.g., a paper at Oxford University
+  // Press would also show up as a "University of Oxford" group).
+  const groupParams = new URLSearchParams({
+    filter: baseFilter,
+    group_by: 'primary_location.source.host_organization',
+    per_page: '200',
+    mailto: MAILTO,
+  });
+  const groupData = await fetchJson<OpenAlexGroupResponse>(
+    `${OPENALEX_BASE}/works?${groupParams.toString()}`
+  );
+  const totalArticles = groupData.meta.count;
+
+  const mappedGroups = new Map<
+    number,
+    { name: string; openalexIds: string[] }
+  >();
+  const unmapped = new Map<string, { name: string; count: number }>();
+  let sumOfGroupCounts = 0;
+
+  for (const group of groupData.group_by) {
+    sumOfGroupCounts += group.count;
+    if (!group.key) continue;
+    const mapping = PUBLISHER_MAP[group.key];
+    if (mapping) {
+      const entry = mappedGroups.get(mapping.crossrefId);
+      if (entry) {
+        entry.openalexIds.push(group.key);
+      } else {
+        mappedGroups.set(mapping.crossrefId, {
+          name: mapping.name,
+          openalexIds: [group.key],
+        });
+      }
+    } else {
+      const displayName = group.key_display_name || 'Unknown publisher';
+      const existing = unmapped.get(group.key);
+      if (existing) {
+        existing.count += group.count;
+      } else {
+        unmapped.set(group.key, { name: displayName, count: group.count });
+      }
+    }
+  }
+
+  // Works whose primary_location.source has no host_organization aren't in any
+  // group_by entry. Surface them explicitly so totals reconcile.
+  const missingHostOrg = totalArticles - sumOfGroupCounts;
+  if (missingHostOrg > 0) {
+    unmapped.set('__no_source__', {
+      name: 'No publisher metadata in OpenAlex',
+      count: missingHostOrg,
+    });
+  }
+
+  // Phase 2: parallel DOI fetch per mapped publisher
+  const mapped = new Map<number, { name: string; dois: string[] }>();
+  const mappedList = Array.from(mappedGroups.entries());
+  await mapWithConcurrency(mappedList, OPENALEX_CONCURRENCY, async ([crossrefId, info]) => {
+    const dois = await fetchPublisherDOIs(baseFilter, info.openalexIds);
+    mapped.set(crossrefId, { name: info.name, dois });
+  });
+
+  return { totalArticles, mapped, unmapped };
+}
+
+async function fetchPublisherDOIs(
+  baseFilter: string,
+  openalexIds: string[]
+): Promise<string[]> {
+  const out: string[] = [];
+  // OpenAlex OR-filter syntax uses `|` between values. Use host_organization
+  // (singular) to match the group_by grouping and avoid ancestor double-counting.
+  const lineageClause = `primary_location.source.host_organization:${openalexIds.join('|')}`;
+  let cursor: string | null = '*';
+  while (cursor !== null) {
+    const currentCursor: string = cursor;
+    const params = new URLSearchParams({
+      filter: `${baseFilter},${lineageClause}`,
+      select: 'doi',
+      per_page: String(OPENALEX_PAGE_SIZE),
+      cursor: currentCursor,
+      mailto: MAILTO,
+    });
+    const data = await fetchJson<OpenAlexDoiResponse>(
+      `${OPENALEX_BASE}/works?${params.toString()}`
+    );
+    for (const w of data.results) {
+      const doi = normalizeDoi(w.doi);
+      if (doi) out.push(doi);
+    }
+    cursor = data.meta.next_cursor;
+    if (cursor && data.results.length === 0) break;
+  }
+  return out;
+}
+
+interface CrossrefWork {
+  DOI?: string;
+  author?: Array<{
+    ORCID?: string;
+    affiliation?: Array<{
+      name?: string;
+      id?: Array<{ id?: string; 'id-type'?: string }>;
+    }>;
+  }>;
+  funder?: Array<unknown>;
+  abstract?: string;
+  license?: Array<unknown>;
+}
+
+interface CrossrefWorksResponse {
+  message: {
+    items: CrossrefWork[];
+    'total-results': number;
+  };
+}
+
+interface WorkInspection {
+  hasAffiliation: boolean;
+  hasAnyRor: boolean;
+  hasInstitutionRor: boolean;
+  hasFunder: boolean;
+  hasAbstract: boolean;
+  hasLicense: boolean;
+  hasOrcid: boolean;
+}
+
+function inspectWork(work: CrossrefWork, institutionRorBare: string): WorkInspection {
+  const authors = work.author || [];
+  let hasAffiliation = false;
+  let hasAnyRor = false;
+  let hasInstitutionRor = false;
+  let hasOrcid = false;
+
+  for (const author of authors) {
+    if (author.ORCID) hasOrcid = true;
+    const affils = author.affiliation || [];
+    for (const af of affils) {
+      if (af.name || (af.id && af.id.length > 0)) hasAffiliation = true;
+      for (const id of af.id || []) {
+        if ((id['id-type'] || '').toUpperCase() === 'ROR') {
+          hasAnyRor = true;
+          const bare = normalizeRor(id.id || '');
+          if (bare === institutionRorBare) hasInstitutionRor = true;
+        }
+      }
+    }
+  }
+
+  return {
+    hasAffiliation,
+    hasAnyRor,
+    hasInstitutionRor,
+    hasFunder: (work.funder || []).length > 0,
+    hasAbstract: typeof work.abstract === 'string' && work.abstract.length > 0,
+    hasLicense: (work.license || []).length > 0,
+    hasOrcid,
+  };
+}
+
+async function fetchCrossrefBatch(dois: string[]): Promise<CrossrefWork[]> {
+  const filter =
+    dois.map((d) => `doi:${d}`).join(',') + `,${CROSSREF_TYPE_FILTER}`;
+  const params = new URLSearchParams({
+    filter,
+    rows: String(dois.length),
+    mailto: MAILTO,
+    select: 'DOI,author,funder,abstract,license',
+  });
+  const url = `${CROSSREF_BASE}/works?${params.toString()}`;
+  const data = await fetchJson<CrossrefWorksResponse>(url);
+  return data.message.items;
+}
+
+interface GapTally {
+  withAffiliation: number;
+  withAnyRor: number;
+  withInstitutionRor: number;
+  withFunder: number;
+  withAbstract: number;
+  withLicense: number;
+  withOrcid: number;
+}
+
+async function measurePublisherGaps(
+  dois: string[],
+  institutionRorBare: string
+): Promise<{ foundInCrossref: number; tally: GapTally }> {
+  const batches: string[][] = [];
+  for (let i = 0; i < dois.length; i += DOI_BATCH_SIZE) {
+    batches.push(dois.slice(i, i + DOI_BATCH_SIZE));
+  }
+
+  // If a single batch fails after retries, skip it rather than tanking the
+  // whole analysis. The remaining batches still produce a valid measurement
+  // (the sample is smaller, but the percentages remain truthful for what was
+  // observed).
+  const batchResults = await mapWithConcurrency(
+    batches,
+    CROSSREF_CONCURRENCY,
+    async (batch) => {
+      try {
+        return await fetchCrossrefBatch(batch);
+      } catch (err) {
+        console.warn(
+          `[analyze-institution] batch of ${batch.length} DOIs failed, skipping: ${String(err).slice(0, 140)}`
+        );
+        return [] as CrossrefWork[];
+      }
+    }
+  );
+
+  const tally: GapTally = {
+    withAffiliation: 0,
+    withAnyRor: 0,
+    withInstitutionRor: 0,
+    withFunder: 0,
+    withAbstract: 0,
+    withLicense: 0,
+    withOrcid: 0,
+  };
+  let foundInCrossref = 0;
+
+  for (const works of batchResults) {
+    for (const work of works) {
+      foundInCrossref += 1;
+      const insp = inspectWork(work, institutionRorBare);
+      if (insp.hasAffiliation) tally.withAffiliation += 1;
+      if (insp.hasAnyRor) tally.withAnyRor += 1;
+      if (insp.hasInstitutionRor) tally.withInstitutionRor += 1;
+      if (insp.hasFunder) tally.withFunder += 1;
+      if (insp.hasAbstract) tally.withAbstract += 1;
+      if (insp.hasLicense) tally.withLicense += 1;
+      if (insp.hasOrcid) tally.withOrcid += 1;
+    }
+  }
+
+  return { foundInCrossref, tally };
+}
+
+function emptyPublisherGap(name: string, crossrefId: number, articles: number): PublisherGap {
+  return {
+    name,
+    crossrefId,
+    articles,
+    measured: false,
+    coverage: { affiliations: 0, rorIds: 0, funders: 0, abstracts: 0, orcids: 0, licenses: 0 },
+    institutionalRor: 0,
+    gap: { noAffiliation: 0, noRor: 0, noFunder: 0, noAbstract: 0, noLicense: 0, noOrcid: 0, noInstitutionalRor: 0 },
+  };
+}
+
+async function measurePublisher(
+  crossrefId: number,
+  name: string,
+  dois: string[],
+  institutionRor: string
+): Promise<PublisherGap> {
+  if (dois.length < MIN_SAMPLE_SIZE) return emptyPublisherGap(name, crossrefId, dois.length);
+
+  const { foundInCrossref, tally } = await measurePublisherGaps(dois, institutionRor);
+  if (foundInCrossref < MIN_SAMPLE_SIZE) return emptyPublisherGap(name, crossrefId, foundInCrossref);
+
+  const pct = (n: number) => (n / foundInCrossref) * 100;
+  return {
+    name,
+    crossrefId,
+    articles: foundInCrossref,
+    measured: true,
+    coverage: {
+      affiliations: pct(tally.withAffiliation),
+      rorIds: pct(tally.withAnyRor),
+      funders: pct(tally.withFunder),
+      abstracts: pct(tally.withAbstract),
+      orcids: pct(tally.withOrcid),
+      licenses: pct(tally.withLicense),
+    },
+    institutionalRor: tally.withInstitutionRor,
+    gap: {
+      noAffiliation: foundInCrossref - tally.withAffiliation,
+      noRor: foundInCrossref - tally.withAnyRor,
+      noFunder: foundInCrossref - tally.withFunder,
+      noAbstract: foundInCrossref - tally.withAbstract,
+      noLicense: foundInCrossref - tally.withLicense,
+      noOrcid: foundInCrossref - tally.withOrcid,
+      noInstitutionalRor: foundInCrossref - tally.withInstitutionRor,
+    },
+  };
+}
+
+export async function analyzeInstitution(
+  rorRaw: string,
+  windowDays: number = WINDOW_DAYS
+): Promise<InstitutionReport> {
+  const ror = normalizeRor(rorRaw);
+
+  const t0 = Date.now();
+  const [institution, { fromDate, dateLabel }] = [
+    await getInstitutionInfo(ror),
+    getDateWindow(windowDays),
+  ];
+  const t1 = Date.now();
+
+  // Kick off cheap 1-year count in parallel with the DOI fetch — used for
+  // annual extrapolation in cost estimates.
+  const annualCountPromise = fetchAnnualArticleCount(ror);
+
+  const { totalArticles, mapped, unmapped } = await fetchInstitutionDOIs(ror, fromDate);
+  const t2 = Date.now();
+
+  const mappedEntries = Array.from(mapped.entries());
+  const publishers = await mapWithConcurrency(
+    mappedEntries,
+    CROSSREF_CONCURRENCY,
+    ([crossrefId, info]) => measurePublisher(crossrefId, info.name, info.dois, ror)
+  );
+  const t3 = Date.now();
+
+  if (process.env.NEXUS_DEBUG_TIMING) {
+    console.log(
+      `  [timing] institution-info=${t1 - t0}ms openalex-dois=${t2 - t1}ms crossref-measure=${t3 - t2}ms total=${t3 - t0}ms`
+    );
+  }
+
+  publishers.sort((a, b) => b.articles - a.articles);
+
+  const unmappedPublishers: UnmappedPublisher[] = Array.from(unmapped.entries())
+    .map(([key, { name, count }]): UnmappedPublisher => {
+      let category: UnmappedPublisher['category'];
+      if (key === '__no_source__') category = 'no-metadata';
+      else if (key.startsWith('https://openalex.org/I')) category = 'institutional';
+      else category = 'unmapped-publisher';
+      return { name, articles: count, category };
+    })
+    .sort((a, b) => b.articles - a.articles);
+
+  const trackedArticles = publishers.reduce((s, p) => s + p.articles, 0);
+  const measured = publishers.filter((p) => p.measured);
+  const measuredArticles = measured.reduce((s, p) => s + p.articles, 0);
+
+  const totals = {
+    noAffiliation: measured.reduce((s, p) => s + p.gap.noAffiliation, 0),
+    noRor: measured.reduce((s, p) => s + p.gap.noRor, 0),
+    noFunder: measured.reduce((s, p) => s + p.gap.noFunder, 0),
+    noAbstract: measured.reduce((s, p) => s + p.gap.noAbstract, 0),
+    noLicense: measured.reduce((s, p) => s + p.gap.noLicense, 0),
+    noInstitutionalRor: measured.reduce((s, p) => s + p.gap.noInstitutionalRor, 0),
+    affiliationPercent: 0,
+    rorPercent: 0,
+    funderPercent: 0,
+    abstractPercent: 0,
+    institutionalRorPercent: 0,
+  };
+
+  if (measuredArticles > 0) {
+    totals.affiliationPercent = ((measuredArticles - totals.noAffiliation) / measuredArticles) * 100;
+    totals.rorPercent = ((measuredArticles - totals.noRor) / measuredArticles) * 100;
+    totals.funderPercent = ((measuredArticles - totals.noFunder) / measuredArticles) * 100;
+    totals.abstractPercent = ((measuredArticles - totals.noAbstract) / measuredArticles) * 100;
+    totals.institutionalRorPercent =
+      ((measuredArticles - totals.noInstitutionalRor) / measuredArticles) * 100;
+  }
+
+  const annualArticleCount = await annualCountPromise;
+
+  return {
+    institution: {
+      name: institution.name,
+      ror,
+      country: institution.country,
+    },
+    dateRange: dateLabel,
+    windowDays,
+    totalArticles,
+    annualArticleCount,
+    trackedArticles,
+    measuredArticles,
+    publishers,
+    unmappedPublishers,
+    totals,
+    generatedAt: new Date().toISOString(),
+    notes: {
+      contentType: 'Journal articles only',
+      source:
+        'Counts are observed directly from Crossref work records, not projected from publisher-wide aggregate coverage.',
+      minSampleSize: MIN_SAMPLE_SIZE,
+    },
+  };
+}

--- a/apps/web/src/lib/publisher-map.ts
+++ b/apps/web/src/lib/publisher-map.ts
@@ -1,0 +1,311 @@
+/**
+ * OpenAlex publisher ID -> Crossref member ID mapping.
+ *
+ * Each Crossref member may be represented in OpenAlex by multiple publisher
+ * entities (parent + L1/L2 children, imprints, regional arms). Any of these
+ * OpenAlex IDs that deposit under the same Crossref member must aggregate here.
+ * Missing an alternate ID means that publisher's articles get silently dropped
+ * into the "Not analyzed" bucket — so the map must be kept current.
+ *
+ * Grouping uses `primary_location.source.host_organization` (singular) to avoid
+ * ancestor double-counting from `host_organization_lineage`.
+ */
+
+export interface PublisherInfo {
+  crossrefId: number;
+  name: string;
+}
+
+export const PUBLISHER_MAP: Record<string, PublisherInfo> = {
+  // Elsevier (78) — includes RELX parent, plus imprints/subsidiaries
+  'https://openalex.org/P4310320990': { crossrefId: 78, name: 'Elsevier' },
+  'https://openalex.org/I1318003438': { crossrefId: 78, name: 'Elsevier' }, // RELX Group institution entity
+  'https://openalex.org/P4310315673': { crossrefId: 78, name: 'Elsevier' }, // Cell Press
+  'https://openalex.org/P4310319955': { crossrefId: 78, name: 'Elsevier' }, // Academic Press
+  'https://openalex.org/P4310321208': { crossrefId: 78, name: 'Elsevier' }, // Churchill Livingstone
+  'https://openalex.org/P4310320345': { crossrefId: 78, name: 'Elsevier' }, // KeAi (joint Elsevier + China Science Publishing)
+  'https://openalex.org/P4310320479': { crossrefId: 78, name: 'Elsevier' }, // Saunders
+
+  // Springer Nature (297) — parent plus children/imprints
+  'https://openalex.org/P4310319965': { crossrefId: 297, name: 'Springer Nature' },
+  'https://openalex.org/P4310319900': { crossrefId: 297, name: 'Springer Nature' }, // Springer Science+Business Media
+  'https://openalex.org/P4310319908': { crossrefId: 297, name: 'Springer Nature' }, // Nature Portfolio
+  'https://openalex.org/P4310320256': { crossrefId: 297, name: 'Springer Nature' }, // BioMed Central
+  'https://openalex.org/P4310319703': { crossrefId: 297, name: 'Springer Nature' }, // Palgrave Macmillan (primary)
+  'https://openalex.org/P4310319702': { crossrefId: 297, name: 'Springer Nature' }, // Palgrave Macmillan (alternate entity)
+  'https://openalex.org/P4310319972': { crossrefId: 297, name: 'Springer Nature' }, // Springer International Publishing
+  'https://openalex.org/P4310320330': { crossrefId: 297, name: 'Springer Nature' }, // Adis, Springer Healthcare
+  'https://openalex.org/P4310320267': { crossrefId: 297, name: 'Springer Nature' }, // Pleiades Publishing
+  'https://openalex.org/P4310320108': { crossrefId: 297, name: 'Springer Nature' }, // Springer Nature (Netherlands)
+  'https://openalex.org/P4310319986': { crossrefId: 297, name: 'Springer Nature' }, // Springer VS
+  'https://openalex.org/P4310319879': { crossrefId: 297, name: 'Springer Nature' }, // J.B. Metzler
+  'https://openalex.org/P4310321666': { crossrefId: 297, name: 'Springer Nature' }, // Springer Vienna
+  'https://openalex.org/P4310320090': { crossrefId: 297, name: 'Springer Nature' }, // Springer Medizin
+  'https://openalex.org/P4310319985': { crossrefId: 297, name: 'Springer Nature' }, // Spektrum-Verlag
+
+  // Wiley (311) — no distinct OpenAlex children as of this map revision
+  'https://openalex.org/P4310320595': { crossrefId: 311, name: 'Wiley' },
+
+  // Oxford University Press (286)
+  'https://openalex.org/P4310311648': { crossrefId: 286, name: 'Oxford University Press' },
+
+  // Taylor & Francis (301) — includes CRC Press, Routledge, and smaller imprints
+  'https://openalex.org/P4310320547': { crossrefId: 301, name: 'Taylor & Francis' },
+  'https://openalex.org/P4310320584': { crossrefId: 301, name: 'Taylor & Francis' }, // CRC Press
+  'https://openalex.org/P4310319847': { crossrefId: 301, name: 'Taylor & Francis' }, // Routledge
+  'https://openalex.org/P4310320374': { crossrefId: 301, name: 'Taylor & Francis' }, // Heldref
+  'https://openalex.org/P4310317116': { crossrefId: 301, name: 'Taylor & Francis' }, // Co-Action Publishing
+
+  // Cambridge University Press (56)
+  'https://openalex.org/P4310311721': { crossrefId: 56, name: 'Cambridge University Press' },
+
+  // SAGE (179)
+  'https://openalex.org/P4310320017': { crossrefId: 179, name: 'SAGE' },
+
+  // PLOS (340)
+  'https://openalex.org/P4310315706': { crossrefId: 340, name: 'PLOS' },
+
+  // BMJ (239)
+  'https://openalex.org/P4310319945': { crossrefId: 239, name: 'BMJ' },
+
+  // MDPI (3611)
+  'https://openalex.org/P4310310987': { crossrefId: 3611, name: 'MDPI' },
+
+  // Frontiers (1965)
+  'https://openalex.org/P4310320527': { crossrefId: 1965, name: 'Frontiers' },
+
+  // American Chemical Society (316)
+  'https://openalex.org/P4310320006': { crossrefId: 316, name: 'ACS' },
+
+  // American Physical Society (16)
+  'https://openalex.org/P4310320261': { crossrefId: 16, name: 'APS' },
+
+  // IOP Publishing (266) — parent "Institute of Physics" plus publishing arm
+  'https://openalex.org/P4310311669': { crossrefId: 266, name: 'IOP Publishing' }, // Institute of Physics (parent)
+  'https://openalex.org/P4310320083': { crossrefId: 266, name: 'IOP Publishing' }, // IOP Publishing
+
+  // Wolters Kluwer (276) — Lippincott + Medknow
+  'https://openalex.org/P4310318547': { crossrefId: 276, name: 'Wolters Kluwer' },
+  'https://openalex.org/P4310315671': { crossrefId: 276, name: 'Wolters Kluwer' }, // Lippincott Williams & Wilkins
+  'https://openalex.org/P4310320448': { crossrefId: 276, name: 'Wolters Kluwer' }, // Medknow
+
+  // IEEE (263) — primary entity plus society sub-entities
+  'https://openalex.org/P4310319808': { crossrefId: 263, name: 'IEEE' }, // Primary (1.47M works)
+  'https://openalex.org/P4310320439': { crossrefId: 263, name: 'IEEE' }, // Computer Society
+  'https://openalex.org/P4310320755': { crossrefId: 263, name: 'IEEE' }, // Magnetics Society
+  'https://openalex.org/P4310320753': { crossrefId: 263, name: 'IEEE' }, // Antennas & Propagation Society
+  'https://openalex.org/P4310316002': { crossrefId: 263, name: 'IEEE' }, // Communications Society
+  'https://openalex.org/P4310321027': { crossrefId: 263, name: 'IEEE' }, // Sensors Council
+  'https://openalex.org/P4310322178': { crossrefId: 263, name: 'IEEE' }, // Photonics Society
+  'https://openalex.org/P4310322504': { crossrefId: 263, name: 'IEEE' }, // Engineering in Medicine and Biology
+  'https://openalex.org/P4310322189': { crossrefId: 263, name: 'IEEE' }, // Education Society
+
+  // American Medical Association (10) — note: JAMA Network uses AMA's Crossref member
+  'https://openalex.org/P4310320406': { crossrefId: 10, name: 'AMA' },
+  'https://openalex.org/P4310320259': { crossrefId: 10, name: 'AMA' }, // AMA (alternate listing)
+
+  // Royal Society of Chemistry (292)
+  'https://openalex.org/P4310320556': { crossrefId: 292, name: 'Royal Society of Chemistry' },
+
+  // Cold Spring Harbor Laboratory (246)
+  'https://openalex.org/P4310315909': { crossrefId: 246, name: 'Cold Spring Harbor Laboratory' },
+  'https://openalex.org/I2750212522': { crossrefId: 246, name: 'Cold Spring Harbor Laboratory' },
+
+  // AIP Publishing (317)
+  'https://openalex.org/P4310320257': { crossrefId: 317, name: 'AIP Publishing' },
+
+  // PNAS (341)
+  'https://openalex.org/P4310320052': { crossrefId: 341, name: 'PNAS' },
+
+  // De Gruyter (374)
+  'https://openalex.org/P4310313990': { crossrefId: 374, name: 'De Gruyter' },
+
+  // Emerald (140)
+  'https://openalex.org/P4310319811': { crossrefId: 140, name: 'Emerald' },
+
+  // Hindawi (98) — still has distinct Crossref member despite Wiley acquisition
+  'https://openalex.org/P4310319869': { crossrefId: 98, name: 'Hindawi' },
+
+  // Karger (127)
+  'https://openalex.org/P4310317820': { crossrefId: 127, name: 'Karger' },
+
+  // Thieme (194)
+  'https://openalex.org/P4310320000': { crossrefId: 194, name: 'Thieme' },
+
+  // Princeton University Press (10341)
+  'https://openalex.org/P4310316492': { crossrefId: 10341, name: 'Princeton University Press' },
+
+  // Brill (50)
+  'https://openalex.org/P4310320561': { crossrefId: 50, name: 'Brill' },
+
+  // American Society for Microbiology (235)
+  'https://openalex.org/P4310320263': { crossrefId: 235, name: 'ASM' },
+
+  // American Psychological Association (15)
+  'https://openalex.org/P4310320262': { crossrefId: 15, name: 'APA' },
+
+  // AAAS / Science (221)
+  'https://openalex.org/P4310315823': { crossrefId: 221, name: 'AAAS' },
+
+  // University of Chicago Press (200)
+  'https://openalex.org/P4310315672': { crossrefId: 200, name: 'University of Chicago Press' },
+
+  // EDP Sciences (250)
+  'https://openalex.org/P4310319748': { crossrefId: 250, name: 'EDP Sciences' },
+
+  // World Scientific (26953)
+  'https://openalex.org/P4310319815': { crossrefId: 26953, name: 'World Scientific' },
+
+  // Trans Tech Publications (2457)
+  'https://openalex.org/P4310317839': { crossrefId: 2457, name: 'Trans Tech Publications' },
+
+  // ACM (320)
+  'https://openalex.org/P4310319798': { crossrefId: 320, name: 'ACM' },
+
+  // IOS Press (7437)
+  'https://openalex.org/P4310318577': { crossrefId: 7437, name: 'IOS Press' },
+
+  // AIAA (1387)
+  'https://openalex.org/P4310315709': { crossrefId: 1387, name: 'AIAA' },
+
+  // SPIE (189)
+  'https://openalex.org/P4310315543': { crossrefId: 189, name: 'SPIE' },
+
+  // ASM International — materials society, distinct from ASME (14553)
+  'https://openalex.org/P4310316053': { crossrefId: 14553, name: 'ASM International' },
+
+  // The Royal Society (175)
+  'https://openalex.org/P4310319787': { crossrefId: 175, name: 'The Royal Society' },
+
+  // Optica Publishing Group (formerly OSA) (285)
+  'https://openalex.org/P4310315679': { crossrefId: 285, name: 'Optica Publishing Group' },
+
+  // American Geophysical Union (13)
+  'https://openalex.org/P4310315809': { crossrefId: 13, name: 'American Geophysical Union' },
+
+  // American Society of Civil Engineers (30)
+  'https://openalex.org/P4310315747': { crossrefId: 30, name: 'ASCE' },
+
+  // American Physiological Society (24)
+  'https://openalex.org/P4310320155': { crossrefId: 24, name: 'American Physiological Society' },
+
+  // AAAI — Association for the Advancement of Artificial Intelligence (9382)
+  'https://openalex.org/P4310320058': { crossrefId: 9382, name: 'AAAI' },
+
+  // The Company of Biologists (237)
+  'https://openalex.org/P4310311847': { crossrefId: 237, name: 'The Company of Biologists' },
+
+  // Copernicus (3145)
+  'https://openalex.org/P4310313756': { crossrefId: 3145, name: 'Copernicus Publications' },
+
+  // Bentham Science (965)
+  'https://openalex.org/P4310320079': { crossrefId: 965, name: 'Bentham Science' },
+
+  // Society for Neuroscience (393)
+  'https://openalex.org/P4310319739': { crossrefId: 393, name: 'Society for Neuroscience' },
+
+  // American Association for Cancer Research (1086)
+  'https://openalex.org/P4310320273': { crossrefId: 1086, name: 'AACR' },
+
+  // eLife (4374)
+  'https://openalex.org/P4310311710': { crossrefId: 4374, name: 'eLife' },
+
+  // Massachusetts Medical Society — publisher of NEJM (150)
+  'https://openalex.org/P4310320239': { crossrefId: 150, name: 'Massachusetts Medical Society' },
+
+  // Wellcome (13928)
+  'https://openalex.org/P4310311838': { crossrefId: 13928, name: 'Wellcome' },
+
+  // JMIR Publications (1010)
+  'https://openalex.org/P4310320608': { crossrefId: 1010, name: 'JMIR Publications' },
+
+  // Microbiology Society (345) — UK, distinct from American Society for Microbiology (235)
+  'https://openalex.org/P4310320497': { crossrefId: 345, name: 'Microbiology Society' },
+
+  // British Editorial Society of Bone & Joint Surgery (42)
+  'https://openalex.org/P4310311815': { crossrefId: 42, name: 'Bone & Joint Surgery' },
+
+  // Royal College of General Practitioners — publisher of BJGP (1987)
+  'https://openalex.org/P4310311776': { crossrefId: 1987, name: 'Royal College of General Practitioners' },
+};
+
+export interface CoverageMetrics {
+  affiliations: number;
+  rorIds: number;
+  funders: number;
+  abstracts: number;
+  orcids: number;
+  licenses: number;
+}
+
+export interface PublisherGap {
+  name: string;
+  crossrefId: number;
+  articles: number;
+  /** True when we measured gaps; false when articles < MIN_SAMPLE_SIZE */
+  measured: boolean;
+  coverage: CoverageMetrics;
+  /** institutionalRor: articles where THIS institution's ROR was deposited on any author */
+  institutionalRor: number;
+  gap: {
+    noAffiliation: number;
+    noRor: number;
+    noFunder: number;
+    noAbstract: number;
+    noLicense: number;
+    noOrcid: number;
+    /** articles missing this institution's ROR specifically (not just any ROR) */
+    noInstitutionalRor: number;
+  };
+}
+
+export interface UnmappedPublisher {
+  name: string;
+  articles: number;
+  /**
+   * Category for the entry:
+   *  - 'no-metadata': OpenAlex itself has no publisher metadata for the article
+   *  - 'institutional': entity is an institution/repo/lab, not a traditional publisher
+   *  - 'unmapped-publisher': a real publisher we haven't added to our Crossref mapping yet
+   */
+  category: 'no-metadata' | 'institutional' | 'unmapped-publisher';
+}
+
+export interface InstitutionReport {
+  institution: {
+    name: string;
+    ror: string;
+    country: string;
+  };
+  dateRange: string;
+  windowDays: number;
+  totalArticles: number;
+  /** Institution's journal-article count in the last 365 days — used for annual extrapolation in cost estimates. */
+  annualArticleCount: number;
+  /** Sum of articles at publishers mapped to Crossref (measured + sampleTooSmall) */
+  trackedArticles: number;
+  /** Sum of articles at publishers mapped AND with sample >= MIN_SAMPLE_SIZE */
+  measuredArticles: number;
+  publishers: PublisherGap[];
+  unmappedPublishers: UnmappedPublisher[];
+  /** Totals computed only over measuredArticles */
+  totals: {
+    noAffiliation: number;
+    noRor: number;
+    noFunder: number;
+    noAbstract: number;
+    noLicense: number;
+    noInstitutionalRor: number;
+    affiliationPercent: number;
+    rorPercent: number;
+    funderPercent: number;
+    abstractPercent: number;
+    institutionalRorPercent: number;
+  };
+  generatedAt: string;
+  notes: {
+    contentType: string;
+    source: string;
+    minSampleSize: number;
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus-score",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Crossref metadata coverage scoring tool",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus-score",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Crossref metadata coverage scoring tool",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-score/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Core scoring library for Crossref metadata coverage",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-score/core",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Core scoring library for Crossref metadata coverage",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-score/mcp-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for Crossref metadata coverage scoring",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-score/mcp-server",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "MCP server for Crossref metadata coverage scoring",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

New `/analysis/institution` page measures **what publishers deposit to Crossref for a given institution's journal articles over the last 90 days** — observed directly from Crossref work records, never projected from publisher-wide aggregate coverage.

Designed to survive scrutiny in real publisher-agreement negotiations. Every number is observation-backed.

## Why this matters

Institutions currently have no direct way to see which publishers actually deposit their ROR, funder, abstract, and other structured metadata to Crossref. Naive approaches project publisher-wide coverage averages onto institutional output — which can overstate or understate the gap, and creates real defamation risk when the numbers end up in contract discussions.

This analysis inspects each Crossref work record for the institution's DOIs individually. If the numbers end up in a contract negotiation, they hold up.

## How it works

1. **OpenAlex** — returns the institution's journal-article DOI list (last 90 days), grouped by publisher via `primary_location.source.host_organization` (singular — not `_lineage`, which would double-count papers under every ancestor).
2. **Crossref** — for each publisher that maps to a Crossref member, DOIs are batch-fetched (40 per call, bounded concurrency) and each work record is inspected locally for: affiliation text, any-ROR, this-institution's-ROR specifically, funder, abstract, license, ORCID.
3. **ROR** is the bridge — OpenAlex asserts "this paper is from institution X"; Crossref deposit may or may not include X's ROR on any author. The `Inst. ROR` column is the strict institutional-attribution test.

Gap counts are aggregated from real observations. Never projected.

## Safeguards against misleading numbers

- **Fixed an ancestor double-counting bug** in the grouping (switched from `host_organization_lineage` to singular `host_organization`).
- **`PUBLISHER_MAP` expanded to ~55 entries**, covering all known sub-entity/imprint OpenAlex IDs for major publishers (Springer children incl. Palgrave's dual ID, IEEE societies, Elsevier imprints incl. Cell Press, T&F incl. Routledge/CRC, Wolters Kluwer incl. Medknow) plus society and university presses previously unmapped (De Gruyter, Emerald, Hindawi, Karger, Thieme, Brill, eLife, NEJM, Wellcome, AAAS, JMIR, ACM, AIAA, SPIE, etc.).
- **Removed a fabricated IEEE OpenAlex ID** (`P4310320430` didn't exist; real one is `P4310319808`).
- **Small samples omitted** — publishers with <10 articles at the institution are shown but not measured.
- **Unanalyzable articles surfaced in a categorized "Why N weren't analyzed" section**, every bucket framed as a publisher deposit gap: no Crossref DOI registered, publisher not yet mapped, or deposit too incomplete for OpenAlex to identify the publisher.
- **Journal articles only** (no proceedings, peer reviews, or book chapters) — avoids the aggregate-score dilution that PR #7 already fixed at the leaderboard layer.
- **Individual Crossref batch failures are tolerated** (logged, skipped) rather than killing the whole analysis.

## Cost calculator

Stakeholder friction section shows observed article counts with illustrative time-per-article midpoints. A floating corner panel lets users plug in their own institutional hourly rates (15-currency dropdown) and extrapolates the observed 90-day gap to an annual cost using the institution's **real** 1-year article count (one additional cheap OpenAlex call). Rates stay client-side — nothing is sent anywhere.

## Methodology cards at top

- **How this analysis works** — data-source breakdown (OpenAlex / Crossref / ROR) and how the numbers are built
- **⚠️ What to keep in mind** — amber caveats, including: ROR has no funder-vs-institution type flag (connects to open issue #2 FundRef→ROR transition), permissive co-author attribution, string-affiliation-without-ROR nuance, point-in-time snapshot, annual-cost extrapolation method
- **What each gap column means** — column-by-column definitions

## API / CLI

```
GET /api/analyze-institution?ror=<ror>&days=<days>
GET /api/analyze-institution?search=<name>
```

```
pnpm --filter web analyze:institution -- --ror 052gg0110
pnpm --filter web analyze:institution -- --search "IISc" --days 90
```

`maxDuration` set to 60s on the serverless route.

## Version

Bumped all tracked workspace packages from `0.1.0` → `0.2.0`.

## Test plan

- [x] Search a small institution (IISc, ROR `04dese585`) — ~12s, ~6 measured publishers
- [x] Search a large institution (Oxford, ROR `052gg0110`) — ~35s, ~15 measured publishers
- [x] Open the cost calculator (bottom-right), fill in a library rate — verify annual $ appears in header card, floating button label, and calculator breakdown
- [x] Change currency to ₹ / € — verify symbols render throughout
- [x] Verify "Why N weren't analyzed" breaks down into 1-3 labeled buckets
- [x] Click methodology cards — verify all three expand with current copy
- [x] `pnpm --filter web build` — passes
- [x] `pnpm --filter web analyze:institution -- --ror 04dese585` — CLI works