### PR TITLE
fix(institution): evidence-based Crossref classification, drop publisher-map gating

### DIFF
--- a/apps/web/scripts/analyze-institution.ts
+++ b/apps/web/scripts/analyze-institution.ts
@@ -43,7 +43,7 @@ function formatReport(report: InstitutionReport): string {
   lines.push(`  ${report.institution.name} (${report.institution.country}) — Research Visibility`);
   lines.push(`  ${report.dateRange}`);
   lines.push(
-    `  ${report.totalArticles.toLocaleString()} articles total | ${report.trackedArticles.toLocaleString()} tracked | ${report.measuredArticles.toLocaleString()} measured`
+    `  ${report.totalArticles.toLocaleString()} OpenAlex article-type works | ${report.analyzedArticles.toLocaleString()} in Crossref as journal-article | ${report.measuredArticles.toLocaleString()} measured`
   );
   lines.push(sep);
   lines.push('');
@@ -74,19 +74,23 @@ function formatReport(report: InstitutionReport): string {
   );
   lines.push(sep);
 
-  if (report.unmappedPublishers.length > 0) {
+  {
+    const s = report.crossrefScope;
+    const belowFloor = report.analyzedArticles - report.measuredArticles;
     lines.push('');
-    lines.push('  NOT ANALYZED (publishers not in our Crossref member mapping)');
+    lines.push('  NOT MEASURED (evidence-based, read from Crossref records)');
     lines.push(thin);
-    const totalUnmapped = report.unmappedPublishers.reduce((s, u) => s + u.articles, 0);
-    for (const u of report.unmappedPublishers.slice(0, 15)) {
-      lines.push(`  ${pad(u.name, 60)} ${padNum(u.articles.toLocaleString(), 8)}`);
+    lines.push(`  ${pad('Not in Crossref (DataCite/repo/preprint)', 60)} ${padNum(s.notInCrossref.toLocaleString(), 8)}`);
+    lines.push(`  ${pad('In Crossref, other content type', 60)} ${padNum(s.otherContentType.toLocaleString(), 8)}`);
+    for (const t of report.otherTypeBreakdown.slice(0, 8)) {
+      lines.push(`  ${pad(`    - ${t.type}`, 60)} ${padNum(t.count.toLocaleString(), 8)}`);
     }
-    if (report.unmappedPublishers.length > 15) {
-      lines.push(`  ... and ${report.unmappedPublishers.length - 15} more`);
+    lines.push(`  ${pad(`Below ${report.notes.minSampleSize}-article sample floor`, 60)} ${padNum(belowFloor.toLocaleString(), 8)}`);
+    lines.push(`  ${pad('No DOI in OpenAlex (nothing to probe)', 60)} ${padNum(s.noDoi.toLocaleString(), 8)}`);
+    lines.push(`  ${pad('Duplicate DOI in OpenAlex (probed once)', 60)} ${padNum(s.duplicateDoi.toLocaleString(), 8)}`);
+    if (s.probeFailed > 0) {
+      lines.push(`  ${pad('Crossref probe unresolved (excluded)', 60)} ${padNum(s.probeFailed.toLocaleString(), 8)}`);
     }
-    lines.push(thin);
-    lines.push(`  ${pad('UNMAPPED TOTAL', 60)} ${padNum(totalUnmapped.toLocaleString(), 8)}`);
     lines.push(sep);
   }
 

--- a/apps/web/src/app/analysis/institution/page.tsx
+++ b/apps/web/src/app/analysis/institution/page.tsx
@@ -17,13 +17,11 @@ interface ProgressState {
   phase: string;
   institutionName: string;
   totalArticles: number;
-  mappedPublishers: number;
-  unmappedPublishers: number;
-  doiCounts: Map<string, number>;
-  crossrefTotal: number;
-  crossrefCompleted: number;
-  crossrefPublisher: string;
-  doisInspected: number;
+  doisFetched: number;
+  probed: number;
+  probeTotal: number;
+  foundArticles: number;
+  publishers: number;
   startedAt: number;
 }
 
@@ -31,13 +29,11 @@ const initialProgress = (): ProgressState => ({
   phase: 'Starting analysis…',
   institutionName: '',
   totalArticles: 0,
-  mappedPublishers: 0,
-  unmappedPublishers: 0,
-  doiCounts: new Map(),
-  crossrefTotal: 0,
-  crossrefCompleted: 0,
-  crossrefPublisher: '',
-  doisInspected: 0,
+  doisFetched: 0,
+  probed: 0,
+  probeTotal: 0,
+  foundArticles: 0,
+  publishers: 0,
   startedAt: Date.now(),
 });
 
@@ -95,7 +91,7 @@ export default function InstitutionAnalysisPage() {
 
   function applyEvent(event: ProgressEvent) {
     setProgress((prev) => {
-      const next = { ...prev, doiCounts: new Map(prev.doiCounts) };
+      const next = { ...prev };
       switch (event.type) {
         case 'phase':
           next.phase = event.message;
@@ -103,24 +99,22 @@ export default function InstitutionAnalysisPage() {
         case 'institution':
           next.institutionName = event.name;
           break;
-        case 'openalex_groups':
+        case 'openalex_total':
           next.totalArticles = event.totalArticles;
-          next.mappedPublishers = event.mappedPublishers;
-          next.unmappedPublishers = event.unmappedPublishers;
-          next.phase = `Found ${event.totalArticles.toLocaleString()} articles across ${event.mappedPublishers} mapped publishers — fetching DOIs…`;
+          next.phase = `Found ${event.totalArticles.toLocaleString()} journal articles — enumerating every DOI…`;
           break;
         case 'openalex_dois':
-          next.doiCounts.set(event.publisher, event.doisFetched);
+          next.doisFetched = event.fetched;
           break;
-        case 'crossref_start':
-          next.crossrefTotal = event.totalPublishers;
-          next.crossrefCompleted = 0;
-          next.phase = `Inspecting Crossref deposits for ${event.totalDois.toLocaleString()} DOIs across ${event.totalPublishers} publishers…`;
+        case 'crossref_probe':
+          next.probed = event.probed;
+          next.probeTotal = event.total;
+          next.foundArticles = event.foundArticles;
+          next.phase = `Probing Crossref directly: ${event.probed.toLocaleString()} / ${event.total.toLocaleString()} DOIs…`;
           break;
-        case 'crossref_publisher':
-          next.crossrefCompleted = event.completed;
-          next.crossrefPublisher = event.publisher;
-          next.doisInspected += event.doisInspected;
+        case 'crossref_grouped':
+          next.publishers = event.publishers;
+          next.phase = `Grouped ${event.analyzed.toLocaleString()} Crossref journal articles across ${event.publishers} publishers.`;
           break;
       }
       return next;
@@ -239,7 +233,7 @@ export default function InstitutionAnalysisPage() {
           <summary className="cursor-pointer px-4 py-3 font-medium">How this analysis works</summary>
           <div className="space-y-4 border-t border-blue-200 px-4 py-4">
             <p>
-              This page measures <strong>what publishers deposit to Crossref</strong> for your institution&apos;s journal articles. Crossref stores what it receives from publishers — the deposit practices are the variable. The analysis uses three data sources together:
+              This page measures <strong>what publishers deposit to Crossref</strong> for your institution&apos;s journal articles. Crossref stores what it receives from publishers — the deposit practices are the variable. The analysis uses two data sources together:
             </p>
 
             <div className="rounded-md border border-blue-200 bg-white p-3">
@@ -252,7 +246,7 @@ export default function InstitutionAnalysisPage() {
             <div className="rounded-md border border-blue-200 bg-white p-3">
               <p className="font-semibold text-blue-900">2. Crossref — for observed publisher deposits</p>
               <p className="mt-1 text-blue-800">
-                For every DOI OpenAlex returns at each mapped publisher, the tool fetches the actual Crossref work record and inspects it directly. Each record is counted by what it contains — affiliations, ROR IDs, funders, abstracts, licenses, ORCIDs — exactly as the publisher deposited them.
+                Every DOI OpenAlex returns is probed directly against Crossref — no content-type filter. Presence, content type, and the publisher (Crossref member) are read from the Crossref record itself, never inferred from OpenAlex&apos;s publisher attribution. Each record that exists as a journal article is counted by what it contains — affiliations, ROR IDs, funders, abstracts, licenses, ORCIDs — exactly as the publisher deposited them. DOIs Crossref has no record for are reported as out of scope, not as a deposit gap.
               </p>
             </div>
 
@@ -270,7 +264,7 @@ export default function InstitutionAnalysisPage() {
                 <li>If OpenAlex identifies a paper as institutional output but the Crossref deposit has no institutional ROR, that&apos;s counted as a gap — the affiliation exists, the publisher just didn&apos;t deposit it.</li>
                 <li>Only journal articles are inspected — no proceedings, book chapters, or peer reviews — to avoid the content-type dilution that inflates aggregate-style scores.</li>
                 <li>Publishers with fewer than 10 articles from this institution are shown but not measured (sample too small).</li>
-                <li>Articles that can&apos;t be traced to a mapped Crossref deposit are reported separately in &quot;Why N articles weren&apos;t analyzed&quot; with a per-reason breakdown.</li>
+                <li>Every probed DOI is classified by evidence from its Crossref record — in Crossref as a journal article, in Crossref under another content type, or absent from Crossref entirely — and reported in &quot;Why N articles weren&apos;t measured&quot;. There is no hand-maintained publisher map; grouping uses the Crossref member on each record.</li>
                 <li>A single extra OpenAlex count call fetches the institution&apos;s full-year journal-article output; the cost calculator uses that number to extrapolate the observed 90-day gap to an annual rate at your chosen hourly rates.</li>
               </ul>
             </div>
@@ -284,7 +278,7 @@ export default function InstitutionAnalysisPage() {
           </summary>
           <ul className="space-y-2 border-t border-amber-200 px-4 py-4 text-amber-900">
             <li>
-              <strong>Not every article can be analyzed — and every reason is a deposit gap.</strong> Some articles were never registered with Crossref (published only in an institutional repo, preprint server, or data platform); some come from publishers not yet mapped to a Crossref member ID; some have a deposit so incomplete that the publisher itself can&apos;t be identified downstream. The &quot;Why N articles weren&apos;t analyzed&quot; section below breaks these down.
+              <strong>Not every article can be measured — and the reasons are not all deposit gaps.</strong> Some articles are absent from Crossref entirely (registered with DataCite, an institutional repository, or a preprint/data platform) — these are genuinely <em>out of scope</em>, not a publisher failing. Others are in Crossref but registered under a different content type, which <em>is</em> a deposit gap. The rest fall below the sample floor. The &quot;Why N articles weren&apos;t measured&quot; section breaks these down from the actual Crossref records — never from a name heuristic.
             </li>
             <li>
               <strong>Author attribution is permissive.</strong> A paper is treated as &quot;from this institution&quot; if any author is affiliated with it. A co-authored paper with 20 authors across 5 institutions counts once for each — the deposit may or may not actually include this institution&apos;s ROR even when the institutional link is real.
@@ -448,36 +442,57 @@ export default function InstitutionAnalysisPage() {
               </div>
             </div>
 
-            {report.unmappedPublishers.length > 0 && (() => {
-              const totalUnmapped = report.unmappedPublishers.reduce((s, u) => s + u.articles, 0);
-              const noMetadata = report.unmappedPublishers.filter((u) => u.category === 'no-metadata').reduce((s, u) => s + u.articles, 0);
-              const institutional = report.unmappedPublishers.filter((u) => u.category === 'institutional').reduce((s, u) => s + u.articles, 0);
-              const unmappedPub = report.unmappedPublishers.filter((u) => u.category === 'unmapped-publisher').reduce((s, u) => s + u.articles, 0);
+            {(() => {
+              const scope = report.crossrefScope;
+              const belowFloor = report.analyzedArticles - report.measuredArticles;
+              const totalNotMeasured =
+                scope.notInCrossref + scope.otherContentType + belowFloor +
+                scope.probeFailed + scope.noDoi + scope.duplicateDoi;
+              if (totalNotMeasured <= 0) return null;
+              const otherTypeList = report.otherTypeBreakdown
+                .slice(0, 4)
+                .map((t) => `${t.type} (${t.count.toLocaleString()})`)
+                .join(', ');
               const rows = [
                 {
-                  count: institutional,
-                  title: 'No Crossref DOI registered at all',
-                  desc: 'The article exists only in an institutional repository, preprint server, or data platform — the publisher never registered a DOI through Crossref. Without a deposit, there\'s nothing to inspect. Smaller publishers, regional outlets, and non-traditional venues often skip Crossref registration entirely.',
+                  count: scope.notInCrossref,
+                  title: 'Not in Crossref at all',
+                  desc: 'Crossref returned no record for the DOI. The work is registered with a different agency — DataCite, an institutional repository, or a preprint/data platform — so it is outside the scope of Crossref deposit measurement. This is not a publisher deposit gap; it is simply not a Crossref object.',
                 },
                 {
-                  count: unmappedPub,
-                  title: 'Publisher deposits exist but aren\'t mapped yet',
-                  desc: 'The publisher does deposit to Crossref, but the mapping table doesn\'t yet link their OpenAlex identity to their Crossref member ID. Fixable — new publishers get added as they surface. Check back in a future run.',
+                  count: scope.otherContentType,
+                  title: 'In Crossref, but not as a journal article',
+                  desc: `The DOI exists in Crossref but is registered under a different content type${otherTypeList ? ` (${otherTypeList})` : ''}. OpenAlex classifies it as an article; the Crossref deposit does not. This content-type mismatch is itself a deposit gap — the work is harder to find as scholarly output.`,
                 },
                 {
-                  count: noMetadata,
-                  title: 'Deposit too incomplete to identify the publisher',
-                  desc: 'OpenAlex attributes the article to this institution but can\'t determine who published it. This typically means the Crossref deposit was missing or skeletal enough that the publisher field couldn\'t be reconstructed — another form of deposit gap, one step removed.',
+                  count: belowFloor,
+                  title: `Below the ${report.notes.minSampleSize}-article sample floor`,
+                  desc: 'These articles are in Crossref and were probed, but their publisher deposited fewer than the minimum number of this institution\'s articles in the window. Coverage percentages on a handful of records are statistically meaningless, so they are reported but not measured.',
+                },
+                {
+                  count: scope.noDoi,
+                  title: 'No DOI in OpenAlex',
+                  desc: 'OpenAlex has the article record but no DOI attached, so there is nothing to look up in Crossref. This is not a Crossref deposit question — without a DOI the work can\'t be cross-referenced at all.',
+                },
+                {
+                  count: scope.duplicateDoi,
+                  title: 'Duplicate DOI in OpenAlex',
+                  desc: 'Multiple OpenAlex work records share a single DOI (e.g. a record split). The DOI is probed once and classified above; the extra records are counted here so the totals reconcile to the OpenAlex universe.',
+                },
+                {
+                  count: scope.probeFailed,
+                  title: 'Crossref probe did not resolve',
+                  desc: 'The Crossref request for these DOIs failed after retries. We do not assume they are absent — they are excluded from every denominator so the percentages stay truthful. Re-running usually resolves these.',
                 },
               ].filter((r) => r.count > 0);
               return (
                 <div className="rounded-lg border bg-white shadow-sm">
                   <div className="border-b px-6 py-4">
                     <h3 className="text-lg font-semibold text-gray-900">
-                      Why {totalUnmapped.toLocaleString()} articles weren&apos;t analyzed — all publisher deposit gaps
+                      Why {totalNotMeasured.toLocaleString()} articles weren&apos;t measured
                     </h3>
                     <p className="mt-1 text-sm text-gray-500">
-                      Of the {report.totalArticles.toLocaleString()} articles OpenAlex attributed to {report.institution.name}, {totalUnmapped.toLocaleString()} couldn&apos;t be measured against Crossref deposits. Every reason below traces back to the same root — <strong>the publisher didn&apos;t deposit complete metadata to Crossref</strong> (or didn&apos;t deposit at all).
+                      Of the {report.totalArticles.toLocaleString()} articles OpenAlex attributed to {report.institution.name}, every DOI was probed directly against Crossref. The breakdown below is <strong>evidence-based</strong> — read from each Crossref record, not inferred from OpenAlex&apos;s publisher attribution. Only &quot;not as a journal article&quot; is a deposit gap; &quot;not in Crossref&quot; is genuinely out of scope.
                     </p>
                     <ScopeStrip report={report} variant="compact" />
                   </div>
@@ -498,7 +513,7 @@ export default function InstitutionAnalysisPage() {
                     ))}
                   </div>
                   <div className="border-t bg-gray-50 px-6 py-3 text-xs text-gray-600">
-                    Every bucket above is a form of deposit gap. Not registering a DOI, depositing incomplete metadata, or skipping Crossref entirely — each leaves institutions with less signal to track their own research.
+                    Presence, content type, and publisher are read from the Crossref record itself. An article counts as &quot;not in Crossref&quot; only when Crossref actually has no record for it — never from a name heuristic.
                   </div>
                 </div>
               );
@@ -522,12 +537,11 @@ function ScopeStrip({
   report: InstitutionReport;
   variant?: 'full' | 'compact';
 }) {
-  const unmappedCount = report.unmappedPublishers.reduce((s, u) => s + u.articles, 0);
   const items = [
-    { label: 'Journal articles total', value: report.totalArticles, tone: 'gray' },
-    { label: 'At publishers mapped to Crossref', value: report.trackedArticles, tone: 'blue' },
+    { label: 'Article-type works (OpenAlex)', value: report.totalArticles, tone: 'gray' },
+    { label: 'In Crossref as journal-article', value: report.analyzedArticles, tone: 'blue' },
     { label: 'Measured', value: report.measuredArticles, tone: 'emerald' },
-    { label: 'At unmapped publishers', value: unmappedCount, tone: 'amber' },
+    { label: 'Not in Crossref', value: report.crossrefScope.notInCrossref, tone: 'amber' },
   ];
 
   const toneClasses: Record<string, { bg: string; text: string; value: string }> = {
@@ -575,14 +589,10 @@ function ProgressPanel({ progress }: { progress: ProgressState }) {
     return () => clearInterval(id);
   }, [progress.startedAt]);
 
-  const totalDois = Array.from(progress.doiCounts.values()).reduce((s, n) => s + n, 0);
   const crossrefPct =
-    progress.crossrefTotal > 0
-      ? Math.round((progress.crossrefCompleted / progress.crossrefTotal) * 100)
+    progress.probeTotal > 0
+      ? Math.round((progress.probed / progress.probeTotal) * 100)
       : 0;
-  const topPublishers = Array.from(progress.doiCounts.entries())
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 5);
 
   return (
     <div className="rounded-lg border bg-white p-6 shadow-sm">
@@ -601,30 +611,30 @@ function ProgressPanel({ progress }: { progress: ProgressState }) {
 
       <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
         <ProgressStat
-          label="Articles found"
+          label="Articles (OpenAlex)"
           value={progress.totalArticles ? progress.totalArticles.toLocaleString() : '—'}
         />
         <ProgressStat
-          label="Mapped publishers"
-          value={progress.mappedPublishers ? `${progress.mappedPublishers}` : '—'}
+          label="DOIs enumerated"
+          value={progress.doisFetched ? progress.doisFetched.toLocaleString() : '—'}
         />
         <ProgressStat
-          label="DOIs fetched"
-          value={totalDois ? totalDois.toLocaleString() : '—'}
+          label="Probed in Crossref"
+          value={progress.probed ? progress.probed.toLocaleString() : '—'}
         />
         <ProgressStat
-          label="DOIs inspected"
-          value={progress.doisInspected ? progress.doisInspected.toLocaleString() : '—'}
+          label="Found as articles"
+          value={progress.foundArticles ? progress.foundArticles.toLocaleString() : '—'}
         />
       </div>
 
-      {progress.crossrefTotal > 0 && (
+      {progress.probeTotal > 0 && (
         <div className="mt-5">
           <div className="mb-1 flex items-center justify-between text-xs text-gray-600">
             <span>
-              Crossref measurement: {progress.crossrefCompleted} / {progress.crossrefTotal} publishers
-              {progress.crossrefPublisher && (
-                <span className="text-gray-400"> · last: {progress.crossrefPublisher}</span>
+              Crossref probe: {progress.probed.toLocaleString()} / {progress.probeTotal.toLocaleString()} DOIs
+              {progress.publishers > 0 && (
+                <span className="text-gray-400"> · {progress.publishers} publishers grouped</span>
               )}
             </span>
             <span className="tabular-nums">{crossrefPct}%</span>
@@ -638,25 +648,10 @@ function ProgressPanel({ progress }: { progress: ProgressState }) {
         </div>
       )}
 
-      {topPublishers.length > 0 && (
-        <div className="mt-5 rounded-md border border-gray-200 bg-gray-50 p-3">
-          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
-            Largest publisher samples so far
-          </p>
-          <ul className="space-y-1 text-sm">
-            {topPublishers.map(([name, count]) => (
-              <li key={name} className="flex justify-between">
-                <span className="truncate text-gray-700">{name}</span>
-                <span className="tabular-nums text-gray-500">{count.toLocaleString()} DOIs</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
       <p className="mt-4 text-xs text-gray-400">
-        Large institutions take longer — every DOI is fetched and every Crossref record is inspected
-        directly. You can leave this tab open; results render as soon as measurement completes.
+        Large institutions take longer — every DOI OpenAlex attributes to this institution is probed
+        directly against Crossref and every returned record is inspected. You can leave this tab
+        open; results render as soon as measurement completes.
       </p>
     </div>
   );

--- a/apps/web/src/lib/analyze-institution.ts
+++ b/apps/web/src/lib/analyze-institution.ts
@@ -2,21 +2,26 @@
  * Institutional research visibility analysis.
  *
  * For a given institution (ROR) over the last N days:
- *   1. Enumerate the institution's journal articles from OpenAlex, grouped by publisher
- *   2. For each publisher we can map to a Crossref member ID, batch-fetch the actual
- *      Crossref work records and inspect each one for metadata presence.
+ *   1. Enumerate ALL of the institution's journal articles from OpenAlex
+ *      (full census, no publisher map gating).
+ *   2. Probe Crossref for every DOI directly — no content-type filter — and
+ *      classify each by EVIDENCE, not by a heuristic on OpenAlex's publisher
+ *      attribution:
+ *        - present in Crossref as a journal-article  -> analyzed
+ *        - present in Crossref under another type     -> content-type deposit gap
+ *        - absent from Crossref entirely              -> registered elsewhere
+ *                                                        (DataCite / repo / preprint)
+ *   3. Group the analyzed works by the Crossref member + publisher Crossref
+ *      itself reports on the record, and inspect each one for metadata presence.
  *
- * Gaps are OBSERVED (counted from real Crossref records), not projected from
- * publisher-wide aggregate coverage. Publishers we can't map to a Crossref member
- * are listed separately so their output is not silently dropped.
+ * Gaps are OBSERVED (counted from real Crossref records), never projected from
+ * aggregate coverage and never inferred from OpenAlex's publisher grouping.
  */
 
 import {
-  PUBLISHER_MAP,
   type InstitutionReport,
   type ProgressEvent,
   type PublisherGap,
-  type UnmappedPublisher,
 } from './publisher-map';
 
 type ProgressFn = (event: ProgressEvent) => void;
@@ -29,35 +34,19 @@ const OPENALEX_API_KEY = process.env.OPENALEX_API_KEY || '';
 
 const WINDOW_DAYS = 90;
 const MIN_SAMPLE_SIZE = 10;
-// Smaller batches keep the Crossref filter URL short and individual responses
-// fast. Each batch is one /works request; 20 DOIs ~= 800-char URL.
-const DOI_BATCH_SIZE = 20;
-const CROSSREF_CONCURRENCY = 5;
-const OPENALEX_CONCURRENCY = 5;
+// One /works request per batch. 40 DOIs ~= a 1,800-char filter URL — well
+// within Crossref's GET limits and 2x fewer round-trips than 20.
+const DOI_BATCH_SIZE = 40;
+const CROSSREF_CONCURRENCY = 6;
 const OPENALEX_PAGE_SIZE = 200;
 // Per-request hard ceiling. Crossref usually answers in <2s; anything past 10s
 // is a stalled connection eating budget we need for the rest of the batches.
 const FETCH_TIMEOUT_MS = 10_000;
-// Statistical sampling cap per publisher. Coverage percentages stabilise long
-// before this; pulling tens of thousands of DOIs blows the serverless budget
-// without changing the conclusion.
-const MAX_DOIS_PER_PUBLISHER = 1000;
-const CONTENT_TYPE_FILTER = 'type:article'; // OpenAlex
-const CROSSREF_TYPE_FILTER = 'type:journal-article';
+const OPENALEX_TYPE_FILTER = 'type:article'; // OpenAlex content type
+const CROSSREF_ARTICLE_TYPE = 'journal-article'; // Crossref work.type value
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
-}
-
-function randomSample<T>(items: T[], n: number): T[] {
-  if (items.length <= n) return items;
-  // Fisher-Yates partial shuffle — O(n) instead of O(items.length).
-  const arr = items.slice();
-  for (let i = 0; i < n; i++) {
-    const j = i + Math.floor(Math.random() * (arr.length - i));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
-  }
-  return arr.slice(0, n);
 }
 
 async function fetchJson<T>(url: string, retries = 2): Promise<T> {
@@ -200,7 +189,7 @@ async function fetchAnnualArticleCount(ror: string): Promise<number> {
     .toISOString()
     .split('T')[0];
   const params = new URLSearchParams({
-    filter: `authorships.institutions.ror:https://ror.org/${ror},from_publication_date:${yearAgo},${CONTENT_TYPE_FILTER}`,
+    filter: `authorships.institutions.ror:https://ror.org/${ror},from_publication_date:${yearAgo},${OPENALEX_TYPE_FILTER}`,
     per_page: '1',
     select: 'id',
     mailto: MAILTO,
@@ -224,119 +213,36 @@ interface OpenAlexDoiResponse {
   results: OpenAlexDoiWork[];
 }
 
-interface OpenAlexGroupResponse {
-  meta: { count: number };
-  group_by: Array<{ key: string; key_display_name: string; count: number }>;
-}
-
 /**
- * Two-phase DOI fetch:
- *   1. One group_by call enumerates publishers with counts.
- *   2. For each publisher we can map to a Crossref member, fetch DOIs in parallel
- *      with a filter that includes only that publisher's OpenAlex lineage IDs
- *      (select=doi to minimise payload). Unmapped publishers are retained from
- *      the group_by counts without fetching DOIs.
+ * Full census: cursor-paginate every journal-article DOI OpenAlex attributes
+ * to this institution in the window. No publisher grouping, no map — the
+ * publisher is whatever Crossref itself reports once we probe each DOI.
  */
-async function fetchInstitutionDOIs(
+async function fetchAllInstitutionDois(
   ror: string,
   fromDate: string,
   onProgress: ProgressFn
 ): Promise<{
   totalArticles: number;
-  mapped: Map<number, { name: string; dois: string[] }>;
-  unmapped: Map<string, { name: string; count: number }>;
+  dois: string[];
+  noDoi: number;
+  duplicateDoi: number;
 }> {
-  const baseFilter = `authorships.institutions.ror:https://ror.org/${ror},from_publication_date:${fromDate},${CONTENT_TYPE_FILTER}`;
-
-  // Phase 1: enumerate publishers via group_by=host_organization (singular, not lineage).
-  // Lineage returns one group per ancestor of each work, which double-counts works
-  // published by a child entity under its parent (e.g., a paper at Oxford University
-  // Press would also show up as a "University of Oxford" group).
-  const groupParams = new URLSearchParams({
-    filter: baseFilter,
-    group_by: 'primary_location.source.host_organization',
-    per_page: '200',
-    mailto: MAILTO,
-  });
-  const groupData = await fetchJson<OpenAlexGroupResponse>(
-    `${OPENALEX_BASE}/works?${groupParams.toString()}`
-  );
-  const totalArticles = groupData.meta.count;
-
-  const mappedGroups = new Map<
-    number,
-    { name: string; openalexIds: string[] }
-  >();
-  const unmapped = new Map<string, { name: string; count: number }>();
-  let sumOfGroupCounts = 0;
-
-  for (const group of groupData.group_by) {
-    sumOfGroupCounts += group.count;
-    if (!group.key) continue;
-    const mapping = PUBLISHER_MAP[group.key];
-    if (mapping) {
-      const entry = mappedGroups.get(mapping.crossrefId);
-      if (entry) {
-        entry.openalexIds.push(group.key);
-      } else {
-        mappedGroups.set(mapping.crossrefId, {
-          name: mapping.name,
-          openalexIds: [group.key],
-        });
-      }
-    } else {
-      const displayName = group.key_display_name || 'Unknown publisher';
-      const existing = unmapped.get(group.key);
-      if (existing) {
-        existing.count += group.count;
-      } else {
-        unmapped.set(group.key, { name: displayName, count: group.count });
-      }
-    }
-  }
-
-  // Works whose primary_location.source has no host_organization aren't in any
-  // group_by entry. Surface them explicitly so totals reconcile.
-  const missingHostOrg = totalArticles - sumOfGroupCounts;
-  if (missingHostOrg > 0) {
-    unmapped.set('__no_source__', {
-      name: 'No publisher metadata in OpenAlex',
-      count: missingHostOrg,
-    });
-  }
-
-  onProgress({
-    type: 'openalex_groups',
-    totalArticles,
-    mappedPublishers: mappedGroups.size,
-    unmappedPublishers: unmapped.size,
-  });
-
-  // Phase 2: parallel DOI fetch per mapped publisher
-  const mapped = new Map<number, { name: string; dois: string[] }>();
-  const mappedList = Array.from(mappedGroups.entries());
-  await mapWithConcurrency(mappedList, OPENALEX_CONCURRENCY, async ([crossrefId, info]) => {
-    const dois = await fetchPublisherDOIs(baseFilter, info.openalexIds);
-    mapped.set(crossrefId, { name: info.name, dois });
-    onProgress({ type: 'openalex_dois', publisher: info.name, doisFetched: dois.length });
-  });
-
-  return { totalArticles, mapped, unmapped };
-}
-
-async function fetchPublisherDOIs(
-  baseFilter: string,
-  openalexIds: string[]
-): Promise<string[]> {
-  const out: string[] = [];
-  // OpenAlex OR-filter syntax uses `|` between values. Use host_organization
-  // (singular) to match the group_by grouping and avoid ancestor double-counting.
-  const lineageClause = `primary_location.source.host_organization:${openalexIds.join('|')}`;
+  const baseFilter = `authorships.institutions.ror:https://ror.org/${ror},from_publication_date:${fromDate},${OPENALEX_TYPE_FILTER}`;
+  const seen = new Set<string>();
+  // OpenAlex article records that can't enter the Crossref probe at all:
+  //   noDoi        — the work has no DOI, so there is nothing to look up
+  //   duplicateDoi — multiple OpenAlex works share one DOI (probed once)
+  // Tracked so the buckets reconcile to totalArticles instead of silently
+  // shrinking to the unique-DOI count.
+  let noDoi = 0;
+  let duplicateDoi = 0;
+  let totalArticles = 0;
   let cursor: string | null = '*';
   while (cursor !== null) {
     const currentCursor: string = cursor;
     const params = new URLSearchParams({
-      filter: `${baseFilter},${lineageClause}`,
+      filter: baseFilter,
       select: 'doi',
       per_page: String(OPENALEX_PAGE_SIZE),
       cursor: currentCursor,
@@ -345,18 +251,32 @@ async function fetchPublisherDOIs(
     const data = await fetchJson<OpenAlexDoiResponse>(
       `${OPENALEX_BASE}/works?${params.toString()}`
     );
+    if (totalArticles === 0 && data.meta.count > 0) {
+      totalArticles = data.meta.count;
+      onProgress({ type: 'openalex_total', totalArticles });
+    }
     for (const w of data.results) {
       const doi = normalizeDoi(w.doi);
-      if (doi) out.push(doi);
+      if (!doi) {
+        noDoi += 1;
+      } else if (seen.has(doi)) {
+        duplicateDoi += 1;
+      } else {
+        seen.add(doi);
+      }
     }
+    onProgress({ type: 'openalex_dois', fetched: seen.size, total: totalArticles });
     cursor = data.meta.next_cursor;
     if (cursor && data.results.length === 0) break;
   }
-  return out;
+  return { totalArticles, dois: Array.from(seen), noDoi, duplicateDoi };
 }
 
 interface CrossrefWork {
   DOI?: string;
+  type?: string;
+  member?: string;
+  publisher?: string;
   author?: Array<{
     ORCID?: string;
     affiliation?: Array<{
@@ -419,14 +339,19 @@ function inspectWork(work: CrossrefWork, institutionRorBare: string): WorkInspec
   };
 }
 
+/**
+ * Probe Crossref for a batch of DOIs. NO content-type filter — we want to know
+ * whether the DOI exists in Crossref at all, then read its type from the
+ * record. That lets us tell "in Crossref but typed differently" apart from
+ * "not in Crossref at all" instead of conflating them.
+ */
 async function fetchCrossrefBatch(dois: string[]): Promise<CrossrefWork[]> {
-  const filter =
-    dois.map((d) => `doi:${d}`).join(',') + `,${CROSSREF_TYPE_FILTER}`;
+  const filter = dois.map((d) => `doi:${d}`).join(',');
   const params = new URLSearchParams({
     filter,
     rows: String(dois.length),
     mailto: MAILTO,
-    select: 'DOI,author,funder,abstract,license',
+    select: 'DOI,member,publisher,type,author,funder,abstract,license',
   });
   const url = `${CROSSREF_BASE}/works?${params.toString()}`;
   const data = await fetchJson<CrossrefWorksResponse>(url);
@@ -443,34 +368,10 @@ interface GapTally {
   withOrcid: number;
 }
 
-async function measurePublisherGaps(
-  dois: string[],
+function tallyWorks(
+  works: CrossrefWork[],
   institutionRorBare: string
-): Promise<{ foundInCrossref: number; tally: GapTally }> {
-  const batches: string[][] = [];
-  for (let i = 0; i < dois.length; i += DOI_BATCH_SIZE) {
-    batches.push(dois.slice(i, i + DOI_BATCH_SIZE));
-  }
-
-  // If a single batch fails after retries, skip it rather than tanking the
-  // whole analysis. The remaining batches still produce a valid measurement
-  // (the sample is smaller, but the percentages remain truthful for what was
-  // observed).
-  const batchResults = await mapWithConcurrency(
-    batches,
-    CROSSREF_CONCURRENCY,
-    async (batch) => {
-      try {
-        return await fetchCrossrefBatch(batch);
-      } catch (err) {
-        console.warn(
-          `[analyze-institution] batch of ${batch.length} DOIs failed, skipping: ${String(err).slice(0, 140)}`
-        );
-        return [] as CrossrefWork[];
-      }
-    }
-  );
-
+): GapTally {
   const tally: GapTally = {
     withAffiliation: 0,
     withAnyRor: 0,
@@ -480,61 +381,43 @@ async function measurePublisherGaps(
     withLicense: 0,
     withOrcid: 0,
   };
-  let foundInCrossref = 0;
-
-  for (const works of batchResults) {
-    for (const work of works) {
-      foundInCrossref += 1;
-      const insp = inspectWork(work, institutionRorBare);
-      if (insp.hasAffiliation) tally.withAffiliation += 1;
-      if (insp.hasAnyRor) tally.withAnyRor += 1;
-      if (insp.hasInstitutionRor) tally.withInstitutionRor += 1;
-      if (insp.hasFunder) tally.withFunder += 1;
-      if (insp.hasAbstract) tally.withAbstract += 1;
-      if (insp.hasLicense) tally.withLicense += 1;
-      if (insp.hasOrcid) tally.withOrcid += 1;
-    }
+  for (const work of works) {
+    const insp = inspectWork(work, institutionRorBare);
+    if (insp.hasAffiliation) tally.withAffiliation += 1;
+    if (insp.hasAnyRor) tally.withAnyRor += 1;
+    if (insp.hasInstitutionRor) tally.withInstitutionRor += 1;
+    if (insp.hasFunder) tally.withFunder += 1;
+    if (insp.hasAbstract) tally.withAbstract += 1;
+    if (insp.hasLicense) tally.withLicense += 1;
+    if (insp.hasOrcid) tally.withOrcid += 1;
   }
-
-  return { foundInCrossref, tally };
+  return tally;
 }
 
-function emptyPublisherGap(name: string, crossrefId: number, articles: number): PublisherGap {
+function buildPublisherGap(
+  crossrefId: number,
+  name: string,
+  works: CrossrefWork[],
+  institutionRor: string
+): PublisherGap {
+  const articles = works.length;
+  if (articles < MIN_SAMPLE_SIZE) {
+    return {
+      name,
+      crossrefId,
+      articles,
+      measured: false,
+      coverage: { affiliations: 0, rorIds: 0, funders: 0, abstracts: 0, orcids: 0, licenses: 0 },
+      institutionalRor: 0,
+      gap: { noAffiliation: 0, noRor: 0, noFunder: 0, noAbstract: 0, noLicense: 0, noOrcid: 0, noInstitutionalRor: 0 },
+    };
+  }
+  const tally = tallyWorks(works, institutionRor);
+  const pct = (n: number) => (n / articles) * 100;
   return {
     name,
     crossrefId,
     articles,
-    measured: false,
-    coverage: { affiliations: 0, rorIds: 0, funders: 0, abstracts: 0, orcids: 0, licenses: 0 },
-    institutionalRor: 0,
-    gap: { noAffiliation: 0, noRor: 0, noFunder: 0, noAbstract: 0, noLicense: 0, noOrcid: 0, noInstitutionalRor: 0 },
-  };
-}
-
-async function measurePublisher(
-  crossrefId: number,
-  name: string,
-  dois: string[],
-  institutionRor: string
-): Promise<PublisherGap> {
-  if (dois.length < MIN_SAMPLE_SIZE) return emptyPublisherGap(name, crossrefId, dois.length);
-
-  // Statistical cap: large-publisher samples (Elsevier, Springer Nature) easily
-  // exceed 5k DOIs in 90 days. Coverage percentages are stable far below that;
-  // we randomly sample to keep the Crossref fetch within the serverless budget.
-  const sample =
-    dois.length > MAX_DOIS_PER_PUBLISHER
-      ? randomSample(dois, MAX_DOIS_PER_PUBLISHER)
-      : dois;
-
-  const { foundInCrossref, tally } = await measurePublisherGaps(sample, institutionRor);
-  if (foundInCrossref < MIN_SAMPLE_SIZE) return emptyPublisherGap(name, crossrefId, foundInCrossref);
-
-  const pct = (n: number) => (n / foundInCrossref) * 100;
-  return {
-    name,
-    crossrefId,
-    articles: foundInCrossref,
     measured: true,
     coverage: {
       affiliations: pct(tally.withAffiliation),
@@ -546,15 +429,120 @@ async function measurePublisher(
     },
     institutionalRor: tally.withInstitutionRor,
     gap: {
-      noAffiliation: foundInCrossref - tally.withAffiliation,
-      noRor: foundInCrossref - tally.withAnyRor,
-      noFunder: foundInCrossref - tally.withFunder,
-      noAbstract: foundInCrossref - tally.withAbstract,
-      noLicense: foundInCrossref - tally.withLicense,
-      noOrcid: foundInCrossref - tally.withOrcid,
-      noInstitutionalRor: foundInCrossref - tally.withInstitutionRor,
+      noAffiliation: articles - tally.withAffiliation,
+      noRor: articles - tally.withAnyRor,
+      noFunder: articles - tally.withFunder,
+      noAbstract: articles - tally.withAbstract,
+      noLicense: articles - tally.withLicense,
+      noOrcid: articles - tally.withOrcid,
+      noInstitutionalRor: articles - tally.withInstitutionRor,
     },
   };
+}
+
+interface ProbeResult {
+  publishers: PublisherGap[];
+  scope: {
+    analyzed: number;
+    otherContentType: number;
+    notInCrossref: number;
+    probeFailed: number;
+  };
+  otherTypeBreakdown: Array<{ type: string; count: number }>;
+}
+
+async function probeAndGroup(
+  dois: string[],
+  institutionRor: string,
+  onProgress: ProgressFn
+): Promise<ProbeResult> {
+  const batches: string[][] = [];
+  for (let i = 0; i < dois.length; i += DOI_BATCH_SIZE) {
+    batches.push(dois.slice(i, i + DOI_BATCH_SIZE));
+  }
+
+  // Each Crossref member becomes one publisher row, named by whatever Crossref
+  // itself reports on the record. No hand-maintained OpenAlex→Crossref map.
+  const groups = new Map<string, { crossrefId: number; name: string; works: CrossrefWork[] }>();
+  const otherTypes = new Map<string, number>();
+  const scope = { analyzed: 0, otherContentType: 0, notInCrossref: 0, probeFailed: 0 };
+  let probed = 0;
+
+  await mapWithConcurrency(batches, CROSSREF_CONCURRENCY, async (batch) => {
+    let items: CrossrefWork[] | null;
+    try {
+      items = await fetchCrossrefBatch(batch);
+    } catch (err) {
+      // Probe failed after retries — don't lie about presence. These DOIs are
+      // excluded from every denominator and surfaced separately.
+      console.warn(
+        `[analyze-institution] Crossref probe of ${batch.length} DOIs failed, marking unresolved: ${String(err).slice(0, 140)}`
+      );
+      items = null;
+    }
+
+    if (items === null) {
+      scope.probeFailed += batch.length;
+    } else {
+      const found = new Map<string, CrossrefWork>();
+      for (const w of items) {
+        const d = normalizeDoi(w.DOI);
+        if (d) found.set(d, w);
+      }
+      for (const doi of batch) {
+        const work = found.get(doi);
+        if (!work) {
+          scope.notInCrossref += 1;
+          continue;
+        }
+        if ((work.type || '').toLowerCase() !== CROSSREF_ARTICLE_TYPE) {
+          scope.otherContentType += 1;
+          const t = work.type || 'unknown';
+          otherTypes.set(t, (otherTypes.get(t) || 0) + 1);
+          continue;
+        }
+        scope.analyzed += 1;
+        const memberId = work.member ? parseInt(work.member, 10) : NaN;
+        const key = Number.isFinite(memberId)
+          ? `m:${memberId}`
+          : `n:${(work.publisher || 'Unknown publisher').toLowerCase()}`;
+        let g = groups.get(key);
+        if (!g) {
+          g = {
+            crossrefId: Number.isFinite(memberId) ? memberId : 0,
+            name: work.publisher || 'Unknown publisher',
+            works: [],
+          };
+          groups.set(key, g);
+        }
+        g.works.push(work);
+      }
+    }
+
+    probed += batch.length;
+    onProgress({
+      type: 'crossref_probe',
+      probed,
+      total: dois.length,
+      foundArticles: scope.analyzed,
+    });
+  });
+
+  const publishers = Array.from(groups.values())
+    .map((g) => buildPublisherGap(g.crossrefId, g.name, g.works, institutionRor))
+    .sort((a, b) => b.articles - a.articles);
+
+  const otherTypeBreakdown = Array.from(otherTypes.entries())
+    .map(([type, count]) => ({ type, count }))
+    .sort((a, b) => b.count - a.count);
+
+  onProgress({
+    type: 'crossref_grouped',
+    publishers: publishers.length,
+    analyzed: scope.analyzed,
+  });
+
+  return { publishers, scope, otherTypeBreakdown };
 }
 
 export async function analyzeInstitution(
@@ -566,10 +554,8 @@ export async function analyzeInstitution(
 
   const t0 = Date.now();
   onProgress({ type: 'phase', message: 'Looking up institution in OpenAlex…' });
-  const [institution, { fromDate, dateLabel }] = [
-    await getInstitutionInfo(ror),
-    getDateWindow(windowDays),
-  ];
+  const institution = await getInstitutionInfo(ror);
+  const { fromDate, dateLabel } = getDateWindow(windowDays);
   onProgress({
     type: 'institution',
     name: institution.name,
@@ -584,70 +570,34 @@ export async function analyzeInstitution(
 
   onProgress({
     type: 'phase',
-    message: `Fetching ${windowDays}-day journal-article DOIs from OpenAlex…`,
+    message: `Enumerating every ${windowDays}-day journal-article DOI from OpenAlex…`,
   });
-  const { totalArticles, mapped, unmapped } = await fetchInstitutionDOIs(
+  const { totalArticles, dois, noDoi, duplicateDoi } = await fetchAllInstitutionDois(
     ror,
     fromDate,
     onProgress
   );
   const t2 = Date.now();
 
-  const mappedEntries = Array.from(mapped.entries());
-  const totalDois = Array.from(mapped.values()).reduce((s, info) => s + info.dois.length, 0);
   onProgress({
-    type: 'crossref_start',
-    totalPublishers: mappedEntries.length,
-    totalDois,
+    type: 'phase',
+    message: `Probing Crossref for all ${dois.length.toLocaleString()} DOIs…`,
   });
-
-  let completed = 0;
-  const publishers = await mapWithConcurrency(
-    mappedEntries,
-    CROSSREF_CONCURRENCY,
-    async ([crossrefId, info]) => {
-      const result = await measurePublisher(crossrefId, info.name, info.dois, ror);
-      completed += 1;
-      onProgress({
-        type: 'crossref_publisher',
-        publisher: info.name,
-        completed,
-        total: mappedEntries.length,
-        doisInspected: result.articles,
-      });
-      return result;
-    }
+  const { publishers, scope, otherTypeBreakdown } = await probeAndGroup(
+    dois,
+    ror,
+    onProgress
   );
   const t3 = Date.now();
 
   if (process.env.NEXUS_DEBUG_TIMING) {
     console.log(
-      `  [timing] institution-info=${t1 - t0}ms openalex-dois=${t2 - t1}ms crossref-measure=${t3 - t2}ms total=${t3 - t0}ms`
+      `  [timing] institution-info=${t1 - t0}ms openalex-dois=${t2 - t1}ms crossref-probe=${t3 - t2}ms total=${t3 - t0}ms`
     );
   }
 
-  publishers.sort((a, b) => b.articles - a.articles);
-
-  const unmappedPublishers: UnmappedPublisher[] = Array.from(unmapped.entries())
-    .map(([key, { name, count }]): UnmappedPublisher => {
-      let category: UnmappedPublisher['category'];
-      if (key === '__no_source__') category = 'no-metadata';
-      else if (key.startsWith('https://openalex.org/I')) category = 'institutional';
-      else category = 'unmapped-publisher';
-      return { name, articles: count, category };
-    })
-    .sort((a, b) => b.articles - a.articles);
-
-  // trackedArticles = articles at mapped publishers per OpenAlex (pre-Crossref
-  // fetch). This ensures the top-line math reconciles: total = tracked +
-  // unmapped. Some of these may not come back from Crossref when we inspect
-  // them (e.g. the DOI exists but isn't typed as a journal-article in
-  // Crossref) — that shortfall is reflected in measuredArticles being lower.
-  const trackedArticles = Array.from(mapped.values()).reduce(
-    (s, info) => s + info.dois.length,
-    0
-  );
   const measured = publishers.filter((p) => p.measured);
+  const analyzedArticles = scope.analyzed;
   const measuredArticles = measured.reduce((s, p) => s + p.articles, 0);
 
   const totals = {
@@ -685,16 +635,24 @@ export async function analyzeInstitution(
     windowDays,
     totalArticles,
     annualArticleCount,
-    trackedArticles,
+    analyzedArticles,
     measuredArticles,
     publishers,
-    unmappedPublishers,
+    crossrefScope: {
+      analyzed: scope.analyzed,
+      otherContentType: scope.otherContentType,
+      notInCrossref: scope.notInCrossref,
+      probeFailed: scope.probeFailed,
+      noDoi,
+      duplicateDoi,
+    },
+    otherTypeBreakdown,
     totals,
     generatedAt: new Date().toISOString(),
     notes: {
       contentType: 'Journal articles only',
       source:
-        'Counts are observed directly from Crossref work records, not projected from publisher-wide aggregate coverage.',
+        'Every DOI OpenAlex attributes to the institution is probed directly against Crossref. Presence, content type, and publisher are read from the Crossref record itself — not inferred from OpenAlex publisher attribution.',
       minSampleSize: MIN_SAMPLE_SIZE,
     },
   };

--- a/apps/web/src/lib/publisher-map.ts
+++ b/apps/web/src/lib/publisher-map.ts
@@ -1,236 +1,15 @@
 /**
- * OpenAlex publisher ID -> Crossref member ID mapping.
+ * Shared types for the institutional analysis feature.
  *
- * Each Crossref member may be represented in OpenAlex by multiple publisher
- * entities (parent + L1/L2 children, imprints, regional arms). Any of these
- * OpenAlex IDs that deposit under the same Crossref member must aggregate here.
- * Missing an alternate ID means that publisher's articles get silently dropped
- * into the "Not analyzed" bucket — so the map must be kept current.
+ * NOTE: This file used to hold a hand-maintained OpenAlex→Crossref member ID
+ * map (`PUBLISHER_MAP`) that gated which articles got analyzed. That approach
+ * was removed: it dropped real Crossref deposits into an "unmapped" bucket and
+ * guessed "not in Crossref" from a name heuristic. Analysis is now evidence-
+ * based — every DOI is probed against Crossref and grouped by the member +
+ * publisher Crossref itself reports. See `analyze-institution.ts`.
  *
- * Grouping uses `primary_location.source.host_organization` (singular) to avoid
- * ancestor double-counting from `host_organization_lineage`.
+ * (Filename kept to avoid churn across importers; it is types-only now.)
  */
-
-export interface PublisherInfo {
-  crossrefId: number;
-  name: string;
-}
-
-export const PUBLISHER_MAP: Record<string, PublisherInfo> = {
-  // Elsevier (78) — includes RELX parent, plus imprints/subsidiaries
-  'https://openalex.org/P4310320990': { crossrefId: 78, name: 'Elsevier' },
-  'https://openalex.org/I1318003438': { crossrefId: 78, name: 'Elsevier' }, // RELX Group institution entity
-  'https://openalex.org/P4310315673': { crossrefId: 78, name: 'Elsevier' }, // Cell Press
-  'https://openalex.org/P4310319955': { crossrefId: 78, name: 'Elsevier' }, // Academic Press
-  'https://openalex.org/P4310321208': { crossrefId: 78, name: 'Elsevier' }, // Churchill Livingstone
-  'https://openalex.org/P4310320345': { crossrefId: 78, name: 'Elsevier' }, // KeAi (joint Elsevier + China Science Publishing)
-  'https://openalex.org/P4310320479': { crossrefId: 78, name: 'Elsevier' }, // Saunders
-
-  // Springer Nature (297) — parent plus children/imprints
-  'https://openalex.org/P4310319965': { crossrefId: 297, name: 'Springer Nature' },
-  'https://openalex.org/P4310319900': { crossrefId: 297, name: 'Springer Nature' }, // Springer Science+Business Media
-  'https://openalex.org/P4310319908': { crossrefId: 297, name: 'Springer Nature' }, // Nature Portfolio
-  'https://openalex.org/P4310320256': { crossrefId: 297, name: 'Springer Nature' }, // BioMed Central
-  'https://openalex.org/P4310319703': { crossrefId: 297, name: 'Springer Nature' }, // Palgrave Macmillan (primary)
-  'https://openalex.org/P4310319702': { crossrefId: 297, name: 'Springer Nature' }, // Palgrave Macmillan (alternate entity)
-  'https://openalex.org/P4310319972': { crossrefId: 297, name: 'Springer Nature' }, // Springer International Publishing
-  'https://openalex.org/P4310320330': { crossrefId: 297, name: 'Springer Nature' }, // Adis, Springer Healthcare
-  'https://openalex.org/P4310320267': { crossrefId: 297, name: 'Springer Nature' }, // Pleiades Publishing
-  'https://openalex.org/P4310320108': { crossrefId: 297, name: 'Springer Nature' }, // Springer Nature (Netherlands)
-  'https://openalex.org/P4310319986': { crossrefId: 297, name: 'Springer Nature' }, // Springer VS
-  'https://openalex.org/P4310319879': { crossrefId: 297, name: 'Springer Nature' }, // J.B. Metzler
-  'https://openalex.org/P4310321666': { crossrefId: 297, name: 'Springer Nature' }, // Springer Vienna
-  'https://openalex.org/P4310320090': { crossrefId: 297, name: 'Springer Nature' }, // Springer Medizin
-  'https://openalex.org/P4310319985': { crossrefId: 297, name: 'Springer Nature' }, // Spektrum-Verlag
-
-  // Wiley (311) — no distinct OpenAlex children as of this map revision
-  'https://openalex.org/P4310320595': { crossrefId: 311, name: 'Wiley' },
-
-  // Oxford University Press (286)
-  'https://openalex.org/P4310311648': { crossrefId: 286, name: 'Oxford University Press' },
-
-  // Taylor & Francis (301) — includes CRC Press, Routledge, and smaller imprints
-  'https://openalex.org/P4310320547': { crossrefId: 301, name: 'Taylor & Francis' },
-  'https://openalex.org/P4310320584': { crossrefId: 301, name: 'Taylor & Francis' }, // CRC Press
-  'https://openalex.org/P4310319847': { crossrefId: 301, name: 'Taylor & Francis' }, // Routledge
-  'https://openalex.org/P4310320374': { crossrefId: 301, name: 'Taylor & Francis' }, // Heldref
-  'https://openalex.org/P4310317116': { crossrefId: 301, name: 'Taylor & Francis' }, // Co-Action Publishing
-
-  // Cambridge University Press (56)
-  'https://openalex.org/P4310311721': { crossrefId: 56, name: 'Cambridge University Press' },
-
-  // SAGE (179)
-  'https://openalex.org/P4310320017': { crossrefId: 179, name: 'SAGE' },
-
-  // PLOS (340)
-  'https://openalex.org/P4310315706': { crossrefId: 340, name: 'PLOS' },
-
-  // BMJ (239)
-  'https://openalex.org/P4310319945': { crossrefId: 239, name: 'BMJ' },
-
-  // MDPI AG (1968) — NOTE: 3611 is "Pro Pharma Communications", NOT MDPI.
-  'https://openalex.org/P4310310987': { crossrefId: 1968, name: 'MDPI' },
-
-  // Frontiers (1965)
-  'https://openalex.org/P4310320527': { crossrefId: 1965, name: 'Frontiers' },
-
-  // American Chemical Society (316)
-  'https://openalex.org/P4310320006': { crossrefId: 316, name: 'ACS' },
-
-  // American Physical Society (16)
-  'https://openalex.org/P4310320261': { crossrefId: 16, name: 'APS' },
-
-  // IOP Publishing (266) — parent "Institute of Physics" plus publishing arm
-  'https://openalex.org/P4310311669': { crossrefId: 266, name: 'IOP Publishing' }, // Institute of Physics (parent)
-  'https://openalex.org/P4310320083': { crossrefId: 266, name: 'IOP Publishing' }, // IOP Publishing
-
-  // Wolters Kluwer (276) — Lippincott + Medknow
-  'https://openalex.org/P4310318547': { crossrefId: 276, name: 'Wolters Kluwer' },
-  'https://openalex.org/P4310315671': { crossrefId: 276, name: 'Wolters Kluwer' }, // Lippincott Williams & Wilkins
-  'https://openalex.org/P4310320448': { crossrefId: 276, name: 'Wolters Kluwer' }, // Medknow
-
-  // IEEE (263) — primary entity plus society sub-entities
-  'https://openalex.org/P4310319808': { crossrefId: 263, name: 'IEEE' }, // Primary (1.47M works)
-  'https://openalex.org/P4310320439': { crossrefId: 263, name: 'IEEE' }, // Computer Society
-  'https://openalex.org/P4310320755': { crossrefId: 263, name: 'IEEE' }, // Magnetics Society
-  'https://openalex.org/P4310320753': { crossrefId: 263, name: 'IEEE' }, // Antennas & Propagation Society
-  'https://openalex.org/P4310316002': { crossrefId: 263, name: 'IEEE' }, // Communications Society
-  'https://openalex.org/P4310321027': { crossrefId: 263, name: 'IEEE' }, // Sensors Council
-  'https://openalex.org/P4310322178': { crossrefId: 263, name: 'IEEE' }, // Photonics Society
-  'https://openalex.org/P4310322504': { crossrefId: 263, name: 'IEEE' }, // Engineering in Medicine and Biology
-  'https://openalex.org/P4310322189': { crossrefId: 263, name: 'IEEE' }, // Education Society
-
-  // American Medical Association (10) — note: JAMA Network uses AMA's Crossref member
-  'https://openalex.org/P4310320406': { crossrefId: 10, name: 'AMA' },
-  'https://openalex.org/P4310320259': { crossrefId: 10, name: 'AMA' }, // AMA (alternate listing)
-
-  // Royal Society of Chemistry (292)
-  'https://openalex.org/P4310320556': { crossrefId: 292, name: 'Royal Society of Chemistry' },
-
-  // Cold Spring Harbor Laboratory (246)
-  'https://openalex.org/P4310315909': { crossrefId: 246, name: 'Cold Spring Harbor Laboratory' },
-  'https://openalex.org/I2750212522': { crossrefId: 246, name: 'Cold Spring Harbor Laboratory' },
-
-  // AIP Publishing (317)
-  'https://openalex.org/P4310320257': { crossrefId: 317, name: 'AIP Publishing' },
-
-  // PNAS (341)
-  'https://openalex.org/P4310320052': { crossrefId: 341, name: 'PNAS' },
-
-  // De Gruyter / Brill (374) — Brill merged into De Gruyter; Brill's DOI
-  // prefix 10.1163 now deposits under Crossref member 374. The standalone
-  // "Brill" member (50) holds 0 DOIs post-merger.
-  'https://openalex.org/P4310313990': { crossrefId: 374, name: 'De Gruyter' },
-
-  // Emerald (140)
-  'https://openalex.org/P4310319811': { crossrefId: 140, name: 'Emerald' },
-
-  // Hindawi (98) — still has distinct Crossref member despite Wiley acquisition
-  'https://openalex.org/P4310319869': { crossrefId: 98, name: 'Hindawi' },
-
-  // Karger (127)
-  'https://openalex.org/P4310317820': { crossrefId: 127, name: 'Karger' },
-
-  // Thieme (194)
-  'https://openalex.org/P4310320000': { crossrefId: 194, name: 'Thieme' },
-
-  // Princeton University Press (10341)
-  'https://openalex.org/P4310316492': { crossrefId: 10341, name: 'Princeton University Press' },
-
-  // Brill — now deposits under De Gruyter post-merger; Crossref member 50
-  // holds 0 DOIs. Route Brill's OpenAlex entity to De Gruyter's member (374).
-  'https://openalex.org/P4310320561': { crossrefId: 374, name: 'De Gruyter / Brill' },
-
-  // American Society for Microbiology (235)
-  'https://openalex.org/P4310320263': { crossrefId: 235, name: 'ASM' },
-
-  // American Psychological Association (15)
-  'https://openalex.org/P4310320262': { crossrefId: 15, name: 'APA' },
-
-  // AAAS / Science (221)
-  'https://openalex.org/P4310315823': { crossrefId: 221, name: 'AAAS' },
-
-  // University of Chicago Press (200)
-  'https://openalex.org/P4310315672': { crossrefId: 200, name: 'University of Chicago Press' },
-
-  // EDP Sciences (250)
-  'https://openalex.org/P4310319748': { crossrefId: 250, name: 'EDP Sciences' },
-
-  // World Scientific (26953)
-  'https://openalex.org/P4310319815': { crossrefId: 26953, name: 'World Scientific' },
-
-  // Trans Tech Publications (2457)
-  'https://openalex.org/P4310317839': { crossrefId: 2457, name: 'Trans Tech Publications' },
-
-  // ACM (320)
-  'https://openalex.org/P4310319798': { crossrefId: 320, name: 'ACM' },
-
-  // IOS Press (7437)
-  'https://openalex.org/P4310318577': { crossrefId: 7437, name: 'IOS Press' },
-
-  // AIAA (1387)
-  'https://openalex.org/P4310315709': { crossrefId: 1387, name: 'AIAA' },
-
-  // SPIE (189)
-  'https://openalex.org/P4310315543': { crossrefId: 189, name: 'SPIE' },
-
-  // ASM International — materials society, distinct from ASME (14553)
-  'https://openalex.org/P4310316053': { crossrefId: 14553, name: 'ASM International' },
-
-  // The Royal Society (175)
-  'https://openalex.org/P4310319787': { crossrefId: 175, name: 'The Royal Society' },
-
-  // Optica Publishing Group (formerly OSA) (285)
-  'https://openalex.org/P4310315679': { crossrefId: 285, name: 'Optica Publishing Group' },
-
-  // American Geophysical Union (13)
-  'https://openalex.org/P4310315809': { crossrefId: 13, name: 'American Geophysical Union' },
-
-  // American Society of Civil Engineers (30)
-  'https://openalex.org/P4310315747': { crossrefId: 30, name: 'ASCE' },
-
-  // American Physiological Society (24)
-  'https://openalex.org/P4310320155': { crossrefId: 24, name: 'American Physiological Society' },
-
-  // AAAI — Association for the Advancement of Artificial Intelligence (9382)
-  'https://openalex.org/P4310320058': { crossrefId: 9382, name: 'AAAI' },
-
-  // The Company of Biologists (237)
-  'https://openalex.org/P4310311847': { crossrefId: 237, name: 'The Company of Biologists' },
-
-  // Copernicus (3145)
-  'https://openalex.org/P4310313756': { crossrefId: 3145, name: 'Copernicus Publications' },
-
-  // Bentham Science (965)
-  'https://openalex.org/P4310320079': { crossrefId: 965, name: 'Bentham Science' },
-
-  // Society for Neuroscience (393)
-  'https://openalex.org/P4310319739': { crossrefId: 393, name: 'Society for Neuroscience' },
-
-  // American Association for Cancer Research (1086)
-  'https://openalex.org/P4310320273': { crossrefId: 1086, name: 'AACR' },
-
-  // eLife (4374)
-  'https://openalex.org/P4310311710': { crossrefId: 4374, name: 'eLife' },
-
-  // Massachusetts Medical Society — publisher of NEJM (150)
-  'https://openalex.org/P4310320239': { crossrefId: 150, name: 'Massachusetts Medical Society' },
-
-  // Wellcome (13928)
-  'https://openalex.org/P4310311838': { crossrefId: 13928, name: 'Wellcome' },
-
-  // JMIR Publications (1010)
-  'https://openalex.org/P4310320608': { crossrefId: 1010, name: 'JMIR Publications' },
-
-  // Microbiology Society (345) — UK, distinct from American Society for Microbiology (235)
-  'https://openalex.org/P4310320497': { crossrefId: 345, name: 'Microbiology Society' },
-
-  // British Editorial Society of Bone & Joint Surgery (42)
-  'https://openalex.org/P4310311815': { crossrefId: 42, name: 'Bone & Joint Surgery' },
-
-  // Royal College of General Practitioners — publisher of BJGP (1987)
-  'https://openalex.org/P4310311776': { crossrefId: 1987, name: 'Royal College of General Practitioners' },
-};
 
 export interface CoverageMetrics {
   affiliations: number;
@@ -243,6 +22,7 @@ export interface CoverageMetrics {
 
 export interface PublisherGap {
   name: string;
+  /** Crossref member ID as reported on the work record (0 if Crossref omitted it). */
   crossrefId: number;
   articles: number;
   /** True when we measured gaps; false when articles < MIN_SAMPLE_SIZE */
@@ -262,18 +42,6 @@ export interface PublisherGap {
   };
 }
 
-export interface UnmappedPublisher {
-  name: string;
-  articles: number;
-  /**
-   * Category for the entry:
-   *  - 'no-metadata': OpenAlex itself has no publisher metadata for the article
-   *  - 'institutional': entity is an institution/repo/lab, not a traditional publisher
-   *  - 'unmapped-publisher': a real publisher we haven't added to our Crossref mapping yet
-   */
-  category: 'no-metadata' | 'institutional' | 'unmapped-publisher';
-}
-
 /**
  * Streamed events from `analyzeInstitution`. The route emits these as NDJSON
  * so the UI can show live progress instead of a 60-300s blank loader. The
@@ -282,21 +50,10 @@ export interface UnmappedPublisher {
 export type ProgressEvent =
   | { type: 'phase'; message: string }
   | { type: 'institution'; name: string; ror: string; country: string }
-  | {
-      type: 'openalex_groups';
-      totalArticles: number;
-      mappedPublishers: number;
-      unmappedPublishers: number;
-    }
-  | { type: 'openalex_dois'; publisher: string; doisFetched: number }
-  | { type: 'crossref_start'; totalPublishers: number; totalDois: number }
-  | {
-      type: 'crossref_publisher';
-      publisher: string;
-      completed: number;
-      total: number;
-      doisInspected: number;
-    }
+  | { type: 'openalex_total'; totalArticles: number }
+  | { type: 'openalex_dois'; fetched: number; total: number }
+  | { type: 'crossref_probe'; probed: number; total: number; foundArticles: number }
+  | { type: 'crossref_grouped'; publishers: number; analyzed: number }
   | { type: 'done'; report: InstitutionReport }
   | { type: 'error'; message: string };
 
@@ -308,15 +65,38 @@ export interface InstitutionReport {
   };
   dateRange: string;
   windowDays: number;
+  /** Journal articles OpenAlex attributes to the institution in the window (the universe probed). */
   totalArticles: number;
   /** Institution's journal-article count in the last 365 days — used for annual extrapolation in cost estimates. */
   annualArticleCount: number;
-  /** Sum of articles at publishers mapped to Crossref (measured + sampleTooSmall) */
-  trackedArticles: number;
-  /** Sum of articles at publishers mapped AND with sample >= MIN_SAMPLE_SIZE */
+  /** DOIs present in Crossref AS a journal-article (every analyzable record). */
+  analyzedArticles: number;
+  /** Subset of analyzedArticles in publishers with sample >= MIN_SAMPLE_SIZE. */
   measuredArticles: number;
   publishers: PublisherGap[];
-  unmappedPublishers: UnmappedPublisher[];
+  /**
+   * Evidence-based classification of every OpenAlex article-type work. By
+   * construction these reconcile to the OpenAlex universe:
+   *   analyzed + otherContentType + notInCrossref + probeFailed
+   *     + noDoi + duplicateDoi === totalArticles
+   * (subject to minor drift if OpenAlex updates mid-pagination).
+   */
+  crossrefScope: {
+    /** Present in Crossref, type journal-article — fed into `publishers`. */
+    analyzed: number;
+    /** Present in Crossref under a different content type (content-type deposit gap). */
+    otherContentType: number;
+    /** Absent from Crossref entirely — registered with DataCite / a repository / preprint server. */
+    notInCrossref: number;
+    /** Crossref probe failed after retries — excluded from every denominator, not assumed absent. */
+    probeFailed: number;
+    /** OpenAlex has the article record but no DOI — nothing to probe (not a Crossref question). */
+    noDoi: number;
+    /** Multiple OpenAlex works share one DOI; counted once in the probe, the rest tallied here. */
+    duplicateDoi: number;
+  };
+  /** Crossref content types seen for the `otherContentType` bucket, largest first. */
+  otherTypeBreakdown: Array<{ type: string; count: number }>;
   /** Totals computed only over measuredArticles */
   totals: {
     noAffiliation: number;


### PR DESCRIPTION
## Problem

The institution analysis inferred \`unmapped\` / \`not in Crossref\` from OpenAlex \`host_organization\` grouping plus a hand-maintained OpenAlex→Crossref member map. It **never asked Crossref whether the DOIs existed**, so:

- Real Crossref deposits from publishers not in the map were dropped into an "unmapped" bucket (e.g. ~230 spurious for Leiden).
- "No Crossref DOI registered at all" was *guessed from a name pattern* (`host_organization` starting with an OpenAlex institution ID), not verified.

## Fix

Every OpenAlex article-type DOI (full 90-day census) is now probed directly against Crossref with **no content-type filter**, and classified by evidence read from the Crossref record itself:

- in Crossref as **journal-article** → analyzed, grouped by the member + publisher Crossref itself reports (no hand map)
- in Crossref under **another content type** → content-type deposit gap (with per-type breakdown)
- **absent from Crossref** → out of scope (DataCite / repository / preprint), *not* a deposit gap
- **no DOI** / **duplicate DOI** / **probe failed** → reconciled and surfaced, not silently dropped

\`crossrefScope\` now reconciles to \`totalArticles\`. \`PUBLISHER_MAP\` removed from the critical path (\`publisher-map.ts\` is types-only). Methodology notes, scope strip, progress UI and CLI updated; OpenAlex universe relabeled "article-type works" for precision.

### Leiden, verified live

929 OpenAlex article-type works → ~723 in Crossref as journal-article, ~109 other type (91 posted-content, 18 proceedings), ~68 not in Crossref, ~16 no DOI, ~13 duplicate DOIs — reconciles to 929.

## Scope / follow-up

- Web app only. Cost profile is heavier (full census vs map-gated) but within the 300s route limit.
- MCP server still runs the old aggregate-projection logic — tracked in #10 (deferred).